### PR TITLE
fix the monaco install problem on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project implements the website for [ClearlyDefined](https://clearlydefined.
 
 # Getting Started
 1. Set the following environment variables:
-   * REACT_APP_SERVER=[http://localhost:5000 | https://dev-api.clearlydefined.io | ...]
-1. `npm install && npm start`
+   * REACT_APP_SERVER=[http://localhost:4000 | https://dev-api.clearlydefined.io | ...]
+1. `npm install`
+1. `npm start`
 
 That installs all the dependencies and starts the website on http://localhost:3000.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.0.2"
   },
   "scripts": {
-    "copy-monaco": "cpx 'node_modules/monaco-editor/min/vs/**/*' public/vs",
+    "copy-monaco": "node ./src/utils/install-monaco.js",
     "build-css": "node-sass src/ -o src/",
     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",

--- a/src/utils/install-monaco.js
+++ b/src/utils/install-monaco.js
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Goofy little utility used at build time to copy the monaco files from their module to
+// the output dir. Running `cpx` directly from package.json does not work uniformly 
+// across windows and linux.
+require('cpx').copy(
+  'node_modules/monaco-editor/min/vs/**/*',
+  'public/vs',
+  error => {
+    if (error) {
+      console.log(error);
+      process.exit(1);
+    }
+    process.exit(0);
+});


### PR DESCRIPTION
Running `cpx` works differently on window and linux (globing and quoting issues). This adds a tiny helper that does the required work in code rather than command line commands.

I am not able to confirm it is working correctly on linux so not merging yet.