### PR TITLE
Add a new way of browsing component definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This project implements the website for [ClearlyDefined](https://clearlydefined.
 
 # Getting Started
 1. Set the following environment variables:
-   * REACT_APP_SERVER=[http://localhost:5000 | https://dev-api.clearlydefined.io | ...]
-1. `npm install && npm start`
+   * REACT_APP_SERVER=[http://localhost:4000 | https://dev-api.clearlydefined.io | ...]
+1. `npm install`
+1. `npm start`
 
 That installs all the dependencies and starts the website on http://localhost:3000.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8685,9 +8685,9 @@
       }
     },
     "react-bootstrap-typeahead": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-2.2.0.tgz",
-      "integrity": "sha1-FyoXM1pA0UGJiO/SZQL+XTf69Bg=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap-typeahead/-/react-bootstrap-typeahead-2.3.0.tgz",
+      "integrity": "sha1-uPdw6w5VWQtfPT5oES4N+2svXcc=",
       "requires": {
         "classnames": "2.2.5",
         "escape-string-regexp": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lodash": "^4.17.4",
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",
-    "react-bootstrap-typeahead": "^2.2.0",
+    "react-bootstrap-typeahead": "^2.3.0",
     "react-dom": "^16.2.0",
     "react-fontawesome": "^1.6.1",
     "react-monaco-editor": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.0.2"
   },
   "scripts": {
-    "copy-monaco": "cpx 'node_modules/monaco-editor/min/vs/**/*' public/vs",
+    "copy-monaco": "node ./src/utils/install-monaco.js",
     "build-css": "node-sass src/ -o src/",
     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",

--- a/src/actions/packageActions.js
+++ b/src/actions/packageActions.js
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { asyncActions } from './'
-import { getPackage, previewPackage, getPackageList } from '../api/clearlyDefined'
+import { getDefinitions, getPackage, previewPackage, getPackageList } from '../api/clearlyDefined'
 
 export const PACKAGE_GET = 'PACKAGE_GET'
 export const PACKAGE_GET_PROPOSED = 'PACKAGE_GET_PROPOSED'
 export const PACKAGE_PREVIEW = 'PACKAGE_PREVIEW'
 export const PACKAGE_LIST = 'PACKAGE_LIST'
+export const PACKAGE_DEFINITIONS = 'PACKAGE_DEFINITIONS'
 
 export function getPackageAction(token, entity) {
   return (dispatch) => {
@@ -15,6 +16,17 @@ export function getPackageAction(token, entity) {
     dispatch(actions.start())
     return getPackage(token, entity).then(
       result => dispatch(actions.success(result)),
+      error => dispatch(actions.error(error))
+    )
+  }
+}
+
+export function getDefinitionsAction(token, entities) {
+  return (dispatch) => {
+    const actions = asyncActions(PACKAGE_DEFINITIONS)
+    dispatch(actions.start())
+    return getDefinitions(token, entities).then(
+      result => dispatch(actions.success({ add: result })),
       error => dispatch(actions.error(error))
     )
   }

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -7,6 +7,7 @@ export const UI_CURATE_UPDATE_FILTER = 'UI_CURATE_UPDATE_FILTER'
 export const UI_BROWSE_UPDATE_FILTER = 'UI_BROWSE_UPDATE_FILTER'
 export const UI_HARVEST_UPDATE_FILTER = 'UI_HARVEST_UPDATE_FILTER'
 export const UI_HARVEST_UPDATE_QUEUE = 'UI_HARVEST_UPDATE_QUEUE'
+export const UI_COMPONENTS_UPDATE_LIST = 'UI_COMPONENTS_UPDATE_LIST'
 
 export function uiNavigation(navItem) {
   return { type: UI_NAVIGATION, to: navItem }
@@ -30,4 +31,8 @@ export function uiHarvestUpdateFilter(value) {
 
 export function uiHarvestUpdateQueue(value) {
   return { type: UI_HARVEST_UPDATE_QUEUE, result: value }
+}
+
+export function uiComponentsUpdateList(value) {
+  return { type: UI_COMPONENTS_UPDATE_LIST, result: value }
 }

--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -41,6 +41,10 @@ export function getPackage(token, entity) {
   return get(url(`${PACKAGES}/${entity.toUrlPath()}`), token)
 }
 
+export function getDefinitions(token, list) {
+  return post(url(`${PACKAGES}`), token, list)
+}
+
 export async function getPackageList(token, prefix, force = false) {
   if (!force && lastFetchPackageList && (Date.now() - lastFetchPackageList < packageListTTL))
     return { list: packageList}

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import PropTypes from 'prop-types'
+import { RowEntityList, TwoLineEntry, GitHubCommitPicker, NpmVersionPicker } from './'
+import { clone } from 'lodash'
+import FontAwesome from 'react-fontawesome'
+import github from '../images/GitHub-Mark-120px-plus.png'
+import npm from '../images/n-large.png'
+
+export default class ComponentList extends React.Component {
+
+  static propTypes = {
+    list: PropTypes.object.isRequired,
+    listHeight: PropTypes.number,
+    loadMoreRows: PropTypes.func,
+    onRemove: PropTypes.func,
+    onChange: PropTypes.func,
+    noRowsRenderer: PropTypes.func,
+    fetchingRenderer: PropTypes.func,
+  }
+
+  static defaultProps = {
+    loadMoreRows: () => { },
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = { contentSeq: 0, sortOrder: null }
+    this.renderRow = this.renderRow.bind(this)
+    this.renderButtons = props.renderButtons || this.renderButtons.bind(this)
+    this.commitChanged = this.commitChanged.bind(this)
+    this.rowHeight = this.rowHeight.bind(this)
+  }
+
+  removeComponent(component, event) {
+    event.stopPropagation()
+    const { onRemove } = this.props
+    onRemove && onRemove(component)
+  }
+
+  commitChanged(component, value) {
+    const newComponent = clone(component)
+    newComponent.revision = value ? value.sha : null
+    this.setState({ ...this.state, contentSeq: this.state.contentSeq + 1 })
+    const { onChange } = this.props
+    onChange && onChange(component, newComponent)
+  }
+
+  npmVersionChanged(component, value) {
+    const newComponent = clone(component)
+    newComponent.revision = value
+    this.setState({ ...this.state, contentSeq: this.state.contentSeq + 1 })
+    const { onChange } = this.props
+    onChange && onChange(component, newComponent)
+  }
+
+  renderButtons(component) {
+    return (
+      <div className='list-activity-area'>
+        {component.provider === 'github' && <GitHubCommitPicker
+          request={component}
+          defaultInputValue={component.revision}
+          onChange={this.commitChanged.bind(this, component)}
+        />}
+        {component.provider === 'npmjs' && <NpmVersionPicker
+          request={component}
+          defaultInputValue={component.revision}
+          onChange={this.npmVersionChanged.bind(this, component)}
+        />}
+        <FontAwesome name={'times'} className='list-remove' onClick={this.removeComponent.bind(this, component)} />
+      </div>)
+  }
+
+  renderHeadline(component) {
+    const { namespace, name } = component
+    const namespaceText = namespace ? (namespace + '/') : ''
+    return (<span>{namespaceText}{name}</span>)
+  }
+
+  renderMessage(component) {
+    const { type, policy } = component
+    const nameText = type ? <span>{type}&nbsp;</span> : ''
+    const policyText = 'Policy: ' + policy ? policy : 'default'
+    return (<span>{nameText} &nbsp; {policyText}</span>)
+  }
+
+  renderPanel(component) {
+    return <div>This is a component</div>
+  }
+
+  getImage(component) {
+    if (component.provider === 'github')
+      return github
+    if (component.provider === 'npmjs')
+      return npm
+    return null
+  }
+
+  rowHeight({ index }, showExpanded = false) {
+    return showExpanded ? 150 :  50
+  }
+
+  renderRow({ index, key, style }, toggleExpanded = null, showExpanded = false) {
+    const { list } = this.props
+    const component = list.list[index]
+    const clickHandler = toggleExpanded ? () => toggleExpanded(index) : null
+    return (
+      <div key={key} style={style}>
+        <TwoLineEntry
+          image={this.getImage(component)}
+          headline={this.renderHeadline(component)}
+          message={this.renderMessage(component)}
+          buttons={this.renderButtons(component)}
+          onClick={clickHandler}
+          panel={showExpanded ? this.renderPanel(component) : null}
+        />
+      </div>)
+  }
+
+  render() {
+    const { loadMoreRows, listHeight, noRowsRenderer, list, fetchingRenderer } = this.props
+    const { sortOrder, contentSeq } = this.state
+    return (<RowEntityList
+      list={list}
+      loadMoreRows={loadMoreRows}
+      listHeight={listHeight}
+      rowRenderer={this.renderRow}
+      allowExpand
+      rowHeight={this.rowHeight}
+      noRowsRenderer={noRowsRenderer}
+      fetchingRenderer={fetchingRenderer}
+      sortOrder={sortOrder}
+      contentSeq={contentSeq}
+    />)
+  }
+}

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -46,7 +46,7 @@ export default class ComponentList extends React.Component {
   commitChanged(component, value) {
     const newComponent = clone(component)
     newComponent.revision = value ? value.sha : null
-    this.setState({ ...this.state, contentSeq: this.state.contentSeq + 1 })
+    this.incrementSequence()
     const { onChange } = this.props
     onChange && onChange(component, newComponent)
   }
@@ -54,9 +54,13 @@ export default class ComponentList extends React.Component {
   npmVersionChanged(component, value) {
     const newComponent = clone(component)
     newComponent.revision = value
-    this.setState({ ...this.state, contentSeq: this.state.contentSeq + 1 })
+    this.incrementSequence()
     const { onChange } = this.props
     onChange && onChange(component, newComponent)
+  }
+
+  incrementSequence() {
+    this.setState({ ...this.state, contentSeq: this.state.contentSeq + 1 })
   }
 
   renderButtons(component) {

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -12,7 +12,7 @@ export default class FilterBar extends Component {
     value: PropTypes.string,
     options: PropTypes.any,
     onChange: PropTypes.func,
-    className: PropTypes.string
+    clearOnChange: PropTypes.bool
   }
 
   constructor(props) {
@@ -22,10 +22,13 @@ export default class FilterBar extends Component {
   }
 
   onChange(values) {
-    this.props.onChange && values.length && this.props.onChange(values[0].path)
+    const { onChange, clearOnChange } = this.props
+    if (values.length) {
+      onChange && onChange(values[0].path)
+      clearOnChange && setTimeout(() => this.refs.typeahead.getInstance().clear(), 0);
+    }
   }
 
-  
   filter(option, text) {
     if (this.props.value)
       return true;
@@ -36,6 +39,7 @@ export default class FilterBar extends Component {
     const { options } = this.props
     return (
       <Typeahead
+        ref='typeahead'
         placeholder='Component search...'
         onChange={this.onChange}
         options={options.transformedList}

--- a/src/components/GitHubCommitPicker.js
+++ b/src/components/GitHubCommitPicker.js
@@ -4,13 +4,15 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getGitHubRevisions } from '../api/clearlyDefined'
-import { Typeahead } from 'react-bootstrap-typeahead'
+import { Typeahead, Highlighter } from 'react-bootstrap-typeahead'
 
 export default class GitHubCommitPicker extends Component {
 
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
+    defaultInputValue: PropTypes.string,
+    allowNew: PropTypes.bool
   }
 
   constructor(props) {
@@ -51,26 +53,32 @@ export default class GitHubCommitPicker extends Component {
   }
 
   renderMenuItemChildren(option, props) {
-    return option.tag === option.sha ? option.sha : `${option.tag} (${option.sha})`
+    const value = option.tag === option.sha ? option.sha : `${option.tag} (${option.sha})`
+    return <Highlighter search={props.text}>
+      {value}
+    </Highlighter>
   }
 
   filter(option, text) {
-    if (this.props.request.revision)
+    if (!text)
       return true;
-    return option.tag.toLowerCase().indexOf(text.toLowerCase()) !== -1;
+    return option.tag.toLowerCase().indexOf(text.toLowerCase()) !== -1
+      || option.sha.toLowerCase().indexOf(text.toLowerCase()) !== -1
   }
 
   render() {
+    const { defaultInputValue, allowNew } = this.props
     const { customValues, options } = this.state
     const list = customValues.concat(options)
     return (
       <Typeahead
         options={list}
         labelKey='tag'
+        defaultInputValue={defaultInputValue}
         placeholder={options.length === 0 ? 'No tags found, enter a commit hash' : 'Pick a tag or enter a commit hash'}
         onChange={this.onChange}
         bodyContainer
-        allowNew
+        allowNew={allowNew}
         clearButton
         newSelectionPrefix='SHA:'
         emptyLabel=''

--- a/src/components/GitHubCommitPicker.js
+++ b/src/components/GitHubCommitPicker.js
@@ -70,7 +70,7 @@ export default class GitHubCommitPicker extends Component {
     const { defaultInputValue, allowNew } = this.props
     const { customValues, options } = this.state
     const list = customValues.concat(options)
-    return (
+    return (<div onClick={e => e.stopPropagation()}>
       <Typeahead
         options={list}
         labelKey='tag'
@@ -85,6 +85,7 @@ export default class GitHubCommitPicker extends Component {
         filterBy={this.filter}
         selectHintOnEnter
         renderMenuItemChildren={this.renderMenuItemChildren}
-      />)
+      />
+    </div >)
   }
 }

--- a/src/components/GitHubSelector.js
+++ b/src/components/GitHubSelector.js
@@ -10,7 +10,7 @@ import 'react-bootstrap-typeahead/css/Typeahead.css';
 export default class GitHubSelector extends Component {
 
   static propTypes = {
-    onChange: PropTypes.func,
+    onChange: PropTypes.func
   }
 
   constructor(props) {

--- a/src/components/NpmVersionPicker.js
+++ b/src/components/NpmVersionPicker.js
@@ -11,6 +11,7 @@ export default class NpmVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
+    defaultInputValue: PropTypes.string
   }
 
   constructor(props) {
@@ -57,12 +58,14 @@ export default class NpmVersionPicker extends Component {
   }
 
   render() {
+    const { defaultInputValue } = this.props
     const { customValues, options } = this.state
     const list = customValues.concat(options)
     return (
       <Typeahead
         options={list}
         // labelKey='id'
+        defaultInputValue={defaultInputValue}
         placeholder={options.length === 0 ? 'Could not fetch versions, type an NPM version' : 'Pick an NPM version'}
         onChange={this.onChange}
         bodyContainer

--- a/src/components/PageComponentDetails.js
+++ b/src/components/PageComponentDetails.js
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Button, Grid, Row, Col } from 'react-bootstrap'
+import { getPackageListAction, getPackageAction } from '../actions/packageActions'
+import { getCurationAction } from '../actions/curationActions'
+import { getHarvestResultsAction } from '../actions/harvestActions'
+import { uiBrowseUpdateFilter, uiNavigation } from '../actions/ui'
+import { FilterBar, MonacoEditorWrapper, Section } from './'
+import EntitySpec from '../utils/entitySpec';
+import { ROUTE_INSPECT } from '../utils/routingConstants';
+
+class PageComponents extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {}
+    this.filterChanged = this.filterChanged.bind(this)
+    this.editorDidMount = this.editorDidMount.bind(this)
+  }
+
+  componentDidMount() {
+    const { dispatch, token, path, filterValue } = this.props
+    const pathToShow = path ? path : filterValue
+    this.handleNewSpec(pathToShow)
+    dispatch(uiNavigation({ to: ROUTE_INSPECT }))
+    dispatch(getPackageListAction(token))
+  }
+
+  componentWillReceiveProps(newProps) {
+    // if the path is changing, update the filter to match. That will trigger getting the content
+    const newPath = newProps.path
+    if (this.props.path !== newPath)
+      return this.props.dispatch(uiBrowseUpdateFilter(newPath))
+
+    // if the filter is changing (either on its own or because of the path), get the new content
+    const newFilter = newProps.filterValue
+    if (this.props.filterValue !== newFilter)
+      this.handleNewSpec(newFilter)
+  }
+
+  handleNewSpec(newFilter) {
+    const { dispatch, token } = this.props
+    if (!newFilter) {
+      // TODO clear out the "current" values as we are not showing anything.
+      return
+    }
+    const spec = EntitySpec.fromPath(newFilter)
+    dispatch(getPackageAction(token, spec))
+    dispatch(getCurationAction(token, spec))
+    dispatch(getHarvestResultsAction(token, spec))
+  }
+
+  filterChanged(newFilter) {
+    this.props.dispatch(uiBrowseUpdateFilter(newFilter))
+  }
+
+  gotoValue(value) {
+    this.props.history.push(`${ROUTE_INSPECT}${value ? '/' + value : ''}`)
+  }
+
+  editorDidMount(editor, monaco) {
+    this.setState({ ...this.state, editor: editor })
+    editor.focus()
+  }
+
+  renderMissing(value) {
+    return (
+      <Button>Queue harvest</Button>
+    )
+  }
+
+  renderData(value, name, type = 'json', actionButton = null) {
+    return (
+      <Section name={name} actionButton={actionButton}>
+        {this.renderInnerData(value, name, type, actionButton)}
+      </Section>)
+  }
+
+  renderInnerData(value, name, type = 'json', actionButton = null) {
+    if (value.isFetching)
+      return this.renderPlaceholder(`Loading the ${name}`)
+    if (value.error && !value.error.state === 404)
+      return this.renderPlaceholder(`There was a problem loading the ${name}`)
+    if (!value.isFetched)
+      return this.renderPlaceholder('Search for some part of a component name to see details')
+    if (!value.item)
+      return this.renderPlaceholder(`There are no ${name}`, actionButton)
+    const options = {
+      selectOnLineNumbers: true
+    }
+    return (
+      <MonacoEditorWrapper
+        height='400'
+        language={type}
+        value={value.transformed}
+        options={options}
+        editorDidMount={this.editorDidMount}
+      />)
+  }
+
+  renderPlaceholder(message) {
+    return (
+      <div className='placeholder-message inline section-body'>
+        <span>{message}</span>
+      </div>)
+  }
+
+  renderCurationButton() {
+    return (<Button bsStyle='success' className='pull-right'>Add curation</Button>)
+  }
+
+  renderHarvestButton() {
+    return (<Button bsStyle='success' className='pull-right'>Harvest data</Button>)
+  }
+
+  render() {
+    const { filterOptions, filterValue, component, curation, harvest } = this.props
+    return (
+      <Grid className='main-container'>
+        <Row className="show-grid spacer">
+          <Col md={10} mdOffset={1}>
+            <FilterBar options={filterOptions} value={filterValue} onChange={this.filterChanged} />
+          </Col>
+        </Row>
+        <Row className='show-grid'>
+          {this.renderData(component, 'results', 'yaml', this.renderCurationButton())}
+          {this.renderData(curation, 'curations', 'json', this.renderCurationButton())}
+          {this.renderData(harvest, 'harvest data', 'json', this.renderHarvestButton())}
+        </Row>
+      </Grid>
+    )
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    token: state.session.token,
+    path: ownProps.location.pathname.slice(ownProps.match.url.length + 1),
+    filterValue: state.ui.browse.filter,
+    filterOptions: state.package.list,
+    component: state.package.current,
+    curation: state.curation.current,
+    harvest: state.harvest.current
+  }
+}
+export default connect(mapStateToProps)(PageComponents)

--- a/src/components/PageComponents.js
+++ b/src/components/PageComponents.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Grid, Row, Col, Button, ButtonGroup } from 'react-bootstrap'
 import { ROUTE_COMPONENTS } from '../utils/routingConstants'
-import { getPackageListAction } from '../actions/packageActions'
+import { getPackageListAction, getDefinitionsAction } from '../actions/packageActions'
 import { FilterBar, ComponentList, Section } from './'
 import { uiNavigation, uiComponentsUpdateList } from '../actions/ui'
 import EntitySpec from '../utils/entitySpec'
@@ -33,8 +33,11 @@ class PageComponents extends Component {
   }
 
   onAddComponent(value) {
-    const { dispatch } = this.props
+    const { dispatch, token, definitions } = this.props
     const component = EntitySpec.fromPath(value)
+    const path = component.toUrlPath()
+    component.definition = !!definitions[path]
+    !component.definition && dispatch(getDefinitionsAction(token, [path]))
     dispatch(uiComponentsUpdateList({ add: component }))
   }
 
@@ -73,7 +76,7 @@ class PageComponents extends Component {
   }
 
   render() {
-    const { components, filterOptions } = this.props
+    const { components, filterOptions, definitions } = this.props
     return (
       <Grid className='main-container'>
         <Row className='show-grid spacer'>
@@ -89,6 +92,7 @@ class PageComponents extends Component {
             <ComponentList
               list={components}
               listHeight={1000}
+              definitions={definitions}
               noRowsRenderer={this.noRowsRenderer} />
           </div>
         </Section>
@@ -102,6 +106,7 @@ function mapStateToProps(state, ownProps) {
     token: state.session.token, 
     filterValue: state.ui.browse.filter,
     filterOptions: state.package.list,
+    definitions: state.package.bodies,
     components: state.ui.components.componentList
   }
 }

--- a/src/components/RehydrationProvider.js
+++ b/src/components/RehydrationProvider.js
@@ -4,11 +4,11 @@
 // Delays loading untill the store is rehydrated
 import React, { Component } from 'react';
 import { persistStore, createTransform } from 'redux-persist'
-import { ROUTE_ROOT, ROUTE_COMPONENTS, ROUTE_CURATE, ROUTE_HARVEST, ROUTE_ABOUT } from '../utils/routingConstants'
+import { ROUTE_ROOT, ROUTE_COMPONENTS, ROUTE_INSPECT, ROUTE_CURATE, ROUTE_HARVEST, ROUTE_ABOUT } from '../utils/routingConstants'
 import { configureStore } from '../configureStore'
 import { Provider } from 'react-redux'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
-import { App, Landing, PageCurate, PageComponents, PageHarvest } from './'
+import { App, Landing, PageCurate, PageComponents, PageComponentDetails, PageHarvest } from './'
 import { omit } from 'lodash'
 import PageAbout from './PageAbout';
 
@@ -45,6 +45,7 @@ export default class RehydrationDelayedProvider extends Component {
           <App className="App">
             <Switch>
               <Route path={ROUTE_COMPONENTS} component={PageComponents} />
+              <Route path={ROUTE_INSPECT} component={PageComponentDetails} />
               <Route path={ROUTE_CURATE} component={PageCurate} />
               <Route path={ROUTE_HARVEST} component={PageHarvest} />
               <Route path={ROUTE_ABOUT} component={PageAbout} />

--- a/src/components/RowEntityList.js
+++ b/src/components/RowEntityList.js
@@ -55,6 +55,8 @@ export default class RowEntityList extends React.Component {
 
   wrappedRowHeight({ index }) {
     const { allowExpand, rowHeight } = this.props
+    if (typeof rowHeight !== 'function')
+      return rowHeight
     return allowExpand
       ? rowHeight({ index }, this.state.expanded.includes(index))
       : rowHeight({ index })

--- a/src/components/RowEntityList.js
+++ b/src/components/RowEntityList.js
@@ -69,7 +69,7 @@ export default class RowEntityList extends React.Component {
   }
 
   render() {
-    const { loadMoreRows, listHeight, list, contentSeq, sortOrder, rowHeight } = this.props
+    const { loadMoreRows, listHeight, list, contentSeq, sortOrder } = this.props
     if (!list.list || list.list.length === 0)
       return this.wrappedNoRowsRender()
     return (

--- a/src/components/TwoLineEntry.js
+++ b/src/components/TwoLineEntry.js
@@ -12,6 +12,7 @@ export default class TwoLineEntry extends React.Component {
     headline: PropTypes.element,
     message: PropTypes.element,
     onClick: PropTypes.func,
+    panel: PropTypes.element
   }
 
   static defaultProps = {
@@ -19,20 +20,25 @@ export default class TwoLineEntry extends React.Component {
   };
 
   render() {
-    const { buttons, image, headline, message, onClick, letter } = this.props
+    const { buttons, image, headline, message, onClick, letter, panel } = this.props
     return (
-      <div className="list-row" onClick={onClick} >
-        {image && <img className="list-image" src={image} alt="" />}
-        {letter && !image && <span className="list-letter">{letter.slice(0, 1)}</span>}
-        <div className="list-body">
-          <div className="list-headline">
-            {headline}
+      <div>
+        <div className="list-row" onClick={onClick} >
+          {image && <img className="list-image" src={image} alt="" />}
+          {letter && !image && <span className="list-letter">{letter.slice(0, 1)}</span>}
+          <div className="list-body">
+            <div className="list-headline">
+              {headline}
+            </div>
+            <div className="list-message">
+              {message}
+            </div>
           </div>
-          <div className="list-message">
-            {message}
-          </div>
+          {buttons}
         </div>
-        {buttons}
+        {panel && <div className="list-panel">
+          {panel}
+        </div>}
       </div>
     )
   }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 export { default as App } from './App'
+export { default as ComponentList } from './ComponentList'
 export { default as CurationEditor } from './CurationEditor'
 export { default as CurationReview } from './CurationReview'
 export { default as FieldGroup } from './FieldGroup'
@@ -19,6 +20,7 @@ export { default as NpmSelector } from './NpmSelector'
 export { default as NpmVersionPicker } from './NpmVersionPicker'
 export { default as NuGetSelector } from './NuGetSelector'
 export { default as PageAbout } from './PageAbout'
+export { default as PageComponentDetails } from './PageComponentDetails'
 export { default as PageComponents } from './PageComponents'
 export { default as PageCurate } from './PageCurate'
 export { default as PageHarvest } from './PageHarvest'

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -19,3 +19,4 @@ const rootReducer = combineReducers({
 export default rootReducer
 export { default as listReducer } from './listReducer'
 export { default as itemReducer } from './itemReducer'
+export { default as tableReducer } from './tableReducer'

--- a/src/reducers/packageReducer.js
+++ b/src/reducers/packageReducer.js
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { PACKAGE_GET, PACKAGE_GET_PROPOSED, PACKAGE_PREVIEW, PACKAGE_LIST } from '../actions/packageActions'
+import { PACKAGE_GET, PACKAGE_GET_PROPOSED, PACKAGE_DEFINITIONS, PACKAGE_PREVIEW, PACKAGE_LIST } from '../actions/packageActions'
 import itemReducer from './itemReducer'
 import listReducer from './listReducer'
+import tableReducer from './tableReducer'
 import yaml from 'js-yaml'
 
 export default combineReducers({
   current: new itemReducer(PACKAGE_GET, item => yaml.safeDump(item, { sortKeys: true })),
   proposed: new itemReducer(PACKAGE_GET_PROPOSED),
   preview: new itemReducer(PACKAGE_PREVIEW),
-  list: new listReducer(PACKAGE_LIST, item => { return { path: item } })
+  list: new listReducer(PACKAGE_LIST, item => { return { path: item } }),
+  bodies: tableReducer(PACKAGE_DEFINITIONS)
 })

--- a/src/reducers/tableReducer.js
+++ b/src/reducers/tableReducer.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { merge, omit, keys } from 'lodash'
+
+export default (name = '', keyGenerator = Object.toString) => {
+  return (state = {}, action) => {
+    // if there is a group on the action then it must match this reducer's name
+    // otherwise the action type must match the name
+    if ((action.group && action.group !== name) || (action.type !== name))
+      return state
+
+    if (action.context && action.context.clear)
+      return {}
+
+    const { result, error } = action
+
+    if (!(result || error))
+      return state
+
+    if (error) {
+      // TODO figure out what to do here with errors filling the table...
+      return state
+    }
+
+    if (result.remove) {
+      return omit(state, keys(result.remove))
+    }
+
+    if (result.add) {
+      return merge({}, state, result.add)
+    }
+
+    if (result.update) {
+      return merge({}, state, result.add)
+    }
+
+    throw new Error('Invalid action format in TableReducer')
+  }
+}

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { ROUTE_ROOT, ROUTE_CURATE, ROUTE_COMPONENTS, ROUTE_HARVEST, ROUTE_ABOUT } from '../utils/routingConstants'
-import { UI_NAVIGATION, UI_CURATE_UPDATE_FILTER, UI_BROWSE_UPDATE_FILTER, UI_HARVEST_UPDATE_FILTER, UI_HARVEST_UPDATE_QUEUE } from '../actions/ui'
+import { ROUTE_ROOT, ROUTE_CURATE, ROUTE_COMPONENTS, ROUTE_HARVEST, ROUTE_ABOUT, ROUTE_INSPECT } from '../utils/routingConstants'
+import {
+  UI_NAVIGATION, UI_CURATE_UPDATE_FILTER, UI_BROWSE_UPDATE_FILTER,
+  UI_HARVEST_UPDATE_FILTER, UI_HARVEST_UPDATE_QUEUE,
+  UI_COMPONENTS_UPDATE_LIST
+} from '../actions/ui'
 import listReducer, { initialState } from './listReducer';
 import { isEqual } from 'lodash'
 
@@ -23,6 +27,12 @@ const initialStateNavigation = [
   {
     title: "Browse",
     to: ROUTE_COMPONENTS,
+    protected: 1,
+    isSelected: false,
+  },
+  {
+    title: "Inspect",
+    to: ROUTE_INSPECT,
     protected: 1,
     isSelected: false,
   },
@@ -91,8 +101,20 @@ const harvest = (state = initialHarvest, action) => {
   }
 }
 
+const componentList = listReducer(UI_COMPONENTS_UPDATE_LIST, null, isEqual)
+const initialComponents = { componentList: initialState }
+const components = (state = initialComponents, action) => {
+  switch (action.type) {
+    case UI_COMPONENTS_UPDATE_LIST:
+      return { ...state, componentList: componentList(state.componentList, action) }
+    default:
+      return state
+  }
+}
+
 export default combineReducers({
   navigation,
+  components,
   browse,
   curate,
   harvest

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -64,6 +64,26 @@
   text-overflow: ellipsis;
 }
 
+.list-panel {
+  margin-left: 85px;
+  margin-right: 85px;
+  text-overflow: ellipsis;
+  p {
+    margin: 0;
+  }
+  h5 {
+    font-weight: bold;
+    margin-bottom: 2px;
+  }
+}
+
+.list-singleLine {
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .list-activity-area {
   min-width: 200px;
   display: inline-flex;

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -7,10 +7,11 @@
 
 .list-row {
   height: 100%;
+  width: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 0 25px;
+  padding: 5px 25px 5px 25px;
   cursor: pointer;
 }
 

--- a/src/utils/install-monaco.js
+++ b/src/utils/install-monaco.js
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Goofy little utility used at build time to copy the monaco files from their module to
+// the output dir. Running `cpx` directly from package.json does not work uniformly 
+// across windows and linux.
+require('cpx').copy(
+  'node_modules/monaco-editor/min/vs/**/*',
+  'public/vs',
+  error => {
+    if (error) {
+      console.log(error);
+      process.exit(1);
+    }
+    process.exit(0);
+});

--- a/src/utils/routingConstants.js
+++ b/src/utils/routingConstants.js
@@ -3,6 +3,7 @@
 
 export const ROUTE_ABOUT= "/about"
 export const ROUTE_COMPONENTS= "/components"
+export const ROUTE_INSPECT= "/inspect"
 export const ROUTE_CURATE= "/curate"
 export const ROUTE_HARVEST= "/harvest"
 export const ROUTE_ROOT = "/"


### PR DESCRIPTION
The current component definition browsing is very detailed. It is hard to get a big picture of what's going on . This PR introduces a list much like the harvest queue list but with expandable panels for more details on each component. the idea is that you can have a whole set of components and see the overview and then click to get a bit more and then click Inspect (or some such) to get the full detail.

Along the way we added some new concepts and implementation

* row list with expandable panel -- This is an enhancement to `RowEntityList` where each entry has an optional panel below that can optioanlly be shown.
* API for getting batches of definitions -- needed here and elsewhere, this gets the definitions for a set of components in one go.
* "database" for holding objects -- to manage the sets of components, we should be storing the content centrally in the UI and then referencing. Still not quite sure how change propagation and UI refresh are supposed to work but this implementation sorta works.

There are various quirks but want to get this out there so it gets some traffic.