### PR TITLE
use CD structure for harvest request

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -37,7 +37,7 @@ let definitionList = []
 
 export function getHarvestResults(token, entity) {
   // TODO ensure that the entity has data all the way down to the revision (and no more)
-  return get(url(`${HARVEST}/${entity.toUrlPath()}`, { form: 'raw' }), token)
+  return get(url(`${HARVEST}/${entity.toPath()}`, { form: 'raw' }), token)
 }
 
 export function harvest(token, spec) {
@@ -45,15 +45,15 @@ export function harvest(token, spec) {
 }
 
 export function getCuration(token, entity) {
-  return get(url(`${CURATIONS}/${entity.toUrlPath()}`), token)
+  return get(url(`${CURATIONS}/${entity.toPath()}`), token)
 }
 
 export function curate(token, entity, spec) {
-  return patch(url(`${CURATIONS}/${entity.toUrlPath()}`), token, spec)
+  return patch(url(`${CURATIONS}/${entity.toPath()}`), token, spec)
 }
 
 export function getDefinition(token, entity) {
-  return get(url(`${DEFINITIONS}/${entity.toUrlPath()}`), token)
+  return get(url(`${DEFINITIONS}/${entity.toPath()}`), token)
 }
 
 export function getDefinitions(token, list) {
@@ -70,7 +70,7 @@ export async function getDefinitionList(token, prefix, force = false) {
 }
 
 export function previewDefinition(token, entity, curation) {
-  return post(url(`${DEFINITIONS}/${entity.toUrlPath()}`, { preview: true }), token, curation)
+  return post(url(`${DEFINITIONS}/${entity.toPath()}`, { preview: true }), token, curation)
 }
 
 export function getGitHubSearch(token, path) {

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -115,7 +115,7 @@ export default class ComponentList extends React.Component {
 
   renderPanel(component) {
     const { definitions } = this.props
-    const key = component.toUrlPath()
+    const key = component.toPath()
     const definition = definitions[key]
     if (!definition)
       return (<div className={"list-noRows"}>

--- a/src/components/PageComponents.js
+++ b/src/components/PageComponents.js
@@ -35,7 +35,7 @@ class PageComponents extends Component {
   onAddComponent(value) {
     const { dispatch, token, definitions } = this.props
     const component = EntitySpec.fromPath(value)
-    const path = component.toUrlPath()
+    const path = component.toPath()
     component.definition = !!definitions[path]
     !component.definition && dispatch(getDefinitionsAction(token, [path]))
     dispatch(uiComponentsUpdateList({ add: component }))

--- a/src/components/PageCurate.js
+++ b/src/components/PageCurate.js
@@ -50,7 +50,7 @@ class PageCurate extends Component {
       // TODO clear out the "current" values as we are not showing anything.
       return
     }
-    const fullSpec = EntitySpec.fromUrl('cd:' + newFilter);
+    const fullSpec = EntitySpec.fromPath(newFilter);
     this.setState({ ...this.state, entitySpec: fullSpec })
     const currentSpec = Object.assign(Object.create(fullSpec), fullSpec, { pr: null });
     if (fullSpec.pr) {

--- a/src/components/PageHarvest.js
+++ b/src/components/PageHarvest.js
@@ -29,7 +29,7 @@ class PageHarvest extends Component {
   harvestHandler(spec) {
     const { dispatch, token, queue } = this.props
     const requests = queue.list.map(entry => {
-      return { type: entry.tool || entry.type, url: entry.toUrl(), policy: entry.policy }
+      return { tool: entry.tool || entry.type, path: entry.toPath(), policy: entry.policy }
     })
     dispatch(harvestAction(token, requests))
     // TODO clearly the harvest queue when everything is successfully queued

--- a/src/components/PageHarvest.js
+++ b/src/components/PageHarvest.js
@@ -29,7 +29,7 @@ class PageHarvest extends Component {
   harvestHandler(spec) {
     const { dispatch, token, queue } = this.props
     const requests = queue.list.map(entry => {
-      return { tool: entry.tool || entry.type, path: entry.toPath(), policy: entry.policy }
+      return { tool: entry.tool || entry.type, coordinates: entry.toPath(), policy: entry.policy }
     })
     dispatch(harvestAction(token, requests))
     // TODO clearly the harvest queue when everything is successfully queued

--- a/src/utils/entitySpec.js
+++ b/src/utils/entitySpec.js
@@ -21,14 +21,9 @@ function normalize(value, provider, property) {
 }
 
 export default class EntitySpec {
-
   static fromPath(path) {
-    return EntitySpec.fromUrl(`cd:/${path}`)
-  }
-
-  static fromUrl(url) {
     // eslint-disable-next-line
-    const [full, type, provider, namespace, name, revision, prSpec] = url.match(/.*:\/*([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/?([^/]+)?(\/pr\/.+)?/)
+    const [full, type, provider, namespace, name, revision, prSpec] = path.match(/\/*([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\/?([^/]+)?(\/pr\/.+)?/)
     // eslint-disable-next-line
     const [blank, delimiter, pr] = prSpec ? prSpec.split('/') : []
     return new EntitySpec(type, provider, namespace, name, revision, pr)
@@ -43,11 +38,7 @@ export default class EntitySpec {
     this.pr = pr
   }
 
-  toUrl() {
-    return `cd:/${this.toUrlPath()}`
-  }
-
-  toUrlPath() {
+  toPath() {
     const revisionPart = this.revision ? `/${this.revision}` : ''
     const prPart = this.pr ? `/pr/${this.pr}` : ''
     return `${this.type}/${this.provider}/${this.namespace || '-'}/${this.name}${revisionPart}${prPart}`


### PR DESCRIPTION
Previously we used a harvest request body that looked a lot like that of the crawler. E.g., there was as type and a url , ... that is not particularly natural for CD API users. This PR changes to use tool: and coordinates:, concepts that are natural to CD.