### PR TITLE
First stab at remembering FilterBar values

### DIFF
--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -20,6 +20,9 @@ export default class FilterBar extends Component {
     super(props)
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
+    this.state = {
+      value: props.value ? [props.value] : null
+    };
   }
 
   onChange(values) {
@@ -50,6 +53,7 @@ export default class FilterBar extends Component {
         defaultInputValue={defaultValue || ''}
         filterBy={this.filter}
         labelKey='path'
+        selected={this.state.value}
       />
     )
   }

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
@@ -20,15 +20,18 @@ export default class FilterBar extends Component {
     super(props)
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
+    const value = props.value || props.defaultValue
     this.state = {
-      value: props.value ? [props.value] : null
+      // TypeAhead.selected expects null if empty. Concat used because it accepts a single item or array
+      value: value ? [].concat(value) : null
     };
   }
 
   onChange(values) {
     const { onChange, clearOnChange } = this.props
     if (values.length) {
-      onChange && onChange(values[0].path)
+      const {path} = values[0]
+      onChange && onChange(path)
       // timing hack to work around https://github.com/ericgio/react-bootstrap-typeahead/issues/211
       clearOnChange && setTimeout(() => this.refs.typeahead.getInstance().clear(), 0);
     }
@@ -41,7 +44,7 @@ export default class FilterBar extends Component {
   }
 
   render() {
-    const { options, defaultValue } = this.props
+    const { options } = this.props
     return (
       <Typeahead
         ref='typeahead'
@@ -50,7 +53,6 @@ export default class FilterBar extends Component {
         options={options.transformedList}
         isLoading={options.isFetching}
         clearButton
-        defaultInputValue={defaultValue || ''}
         filterBy={this.filter}
         labelKey='path'
         selected={this.state.value}

--- a/src/components/PageComponentDetails.js
+++ b/src/components/PageComponentDetails.js
@@ -1,5 +1,4 @@
-// Copyright (c) Microsoft Corporation and Others.
-// Copyright (c) 2018, The Linux Foundation.
+// Copyright (c) Microsoft Corporation and others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
@@ -23,7 +22,7 @@ class PageInspect extends Component {
 
   componentDidMount() {
     const { dispatch, token, path, filterValue } = this.props
-    const pathToShow = path ? path : filterValue
+    const pathToShow = path || filterValue
     this.handleNewSpec(pathToShow)
     dispatch(uiNavigation({ to: ROUTE_INSPECT }))
     dispatch(getDefinitionListAction(token))
@@ -63,7 +62,7 @@ class PageInspect extends Component {
   }
 
   gotoValue(value) {
-    this.props.history.push(`${ROUTE_INSPECT}${value ? '/' + value : ''}`)
+    this.props.history.push(`${ROUTE_INSPECT}${value ? `/${value}` : ''}`)
   }
 
   editorDidMount(editor, monaco) {
@@ -129,12 +128,15 @@ class PageInspect extends Component {
   }
 
   render() {
-    const { filterOptions, filterValue, definition, curation, harvest } = this.props
+    const { filterOptions, filterValue, definition, curation, harvest, path } = this.props
     return (
       <Grid className='main-container'>
         <Row className="show-grid spacer">
           <Col md={10} mdOffset={1}>
-            <FilterBar options={filterOptions} value={filterValue} onChange={this.filterChanged} />
+            <FilterBar
+              options={filterOptions}
+              value={path || filterValue}
+              onChange={this.filterChanged} />
           </Col>
         </Row>
         <Row className='show-grid'>
@@ -158,4 +160,5 @@ function mapStateToProps(state, ownProps) {
     harvest: state.ui.inspect.harvested
   }
 }
+
 export default connect(mapStateToProps)(PageInspect)

--- a/src/components/PageComponents.js
+++ b/src/components/PageComponents.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation and others. All rights reserved.
+// Copyright (c) Microsoft Corporation and others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
@@ -7,7 +7,7 @@ import { Grid, Row, Col, Button, ButtonGroup } from 'react-bootstrap'
 import { ROUTE_COMPONENTS, ROUTE_INSPECT, ROUTE_CURATE } from '../utils/routingConstants'
 import { getDefinitionListAction, getDefinitionsAction } from '../actions/definitionActions'
 import { FilterBar, ComponentList, Section } from './'
-import { uiNavigation, uiBrowseUpdateList } from '../actions/ui'
+import { uiNavigation, uiBrowseUpdateList, uiInspectUpdateFilter, uiCurateUpdateFilter } from '../actions/ui'
 import EntitySpec from '../utils/entitySpec'
 
 class PageComponents extends Component {
@@ -43,13 +43,17 @@ class PageComponents extends Component {
   }
 
   onCurate(component) {
-    const url = `${ROUTE_CURATE}/${component.toPath()}`
+    const path = component.toPath();
+    const url = `${ROUTE_CURATE}/${path}`
     this.props.history.push(url)
+    this.props.dispatch(uiCurateUpdateFilter(path))
   }
 
   onInspect(component) {
-    const url = `${ROUTE_INSPECT}/${component.toPath()}`
+    const path = component.toPath();
+    const url = `${ROUTE_INSPECT}/${path}`
     this.props.history.push(url)
+    this.props.dispatch(uiInspectUpdateFilter(path))
   }
 
   onRemoveComponent(component) {

--- a/src/components/PageCurate.js
+++ b/src/components/PageCurate.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
@@ -25,7 +25,7 @@ class PageCurate extends Component {
 
   componentDidMount() {
     const { dispatch, token, path, filterValue } = this.props
-    const pathToShow = path ? path : filterValue
+    const pathToShow = path || filterValue
     this.filterChanged(pathToShow)
     dispatch(uiNavigation({ to: ROUTE_CURATE }))
     dispatch(getDefinitionListAction(token))
@@ -35,7 +35,7 @@ class PageCurate extends Component {
     // if the path is changing, update the filter to match. That will trigger getting the content
     const newPath = newProps.path
     if (this.props.path !== newPath)
-      return this.props.dispatch(uiCurateUpdateFilter(newPath))
+      return this.filterChanged(newPath)
 
     // if the filter is changing (either on its own or because of the path), get the new content
     const newFilter = newProps.filterValue
@@ -87,7 +87,7 @@ class PageCurate extends Component {
   }
 
   gotoValue(value) {
-    this.props.history.push(`${ROUTE_CURATE}${value ? '/' + value : ''}`)
+    this.props.history.push(`${ROUTE_CURATE}${value ? `/${value}` : ''}`)
   }
 
   renderPlaceholder(message) {
@@ -140,9 +140,8 @@ class PageCurate extends Component {
           <Col md={searchWidth} mdOffset={1}>
             <FilterBar
               options={filterOptions}
-              value={filterValue}
+              value={path || filterValue}
               onChange={this.filterChanged}
-              defaultValue={path ? path : ''}
             />
           </Col>
           {isCurator && <Col md={4} >


### PR DESCRIPTION
This addresses some of the issues with the FilterBar remembering the selected value. There are still a few things to work out though, but submitting this PR now since I'm out for a couple days.
* I took a stab at keeping the URL up to date with the selected definition but this introduced other problems so I pulled it out for now (i.e. I made progress leveraging `gotoValue` so that the URL also matched what the user selected in the FilterBar, etc but ran into some other funky issues with routing). **We should look to globally solve keeping state and url history in sync.** We may want to look into using `react-router-redux` or something. Ideally we just manage state, and routing is updated automatically (or vice versa - when you navigate somewhere, state gets updated). This needs some more research.
* Curate page: when you select something, browse away and come back, the filterbar value is filled in but the curation is gone. In `PageCurate.componentDidMount` , replacing `this.filterChanged` to `this.handleNewSpec` fixes it but then this breaks deep linking (i.e. when you have a curation in the URL path and refresh).

Fixes #35 