### PR TITLE
Changing email for ClearlyDefined

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -21,7 +21,7 @@ export default class Footer extends Component {
     socials: {
       github: 'https://github.com/clearlydefined',
       website: 'https://clearlydefined.io',
-      email: 'clearlydefined@outlook.com',
+      email: 'clearlydefined@googlegroups.com',
       twitter: 'https://twitter.com/clearlydefd'
     }
   }


### PR DESCRIPTION
Changing email in footer from clearlydefined@outlook.com to clearlydefined@googlegroups.com