### PR TITLE
Remove "All Rights Reserved."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: MIT
 FROM node:8-alpine as builder
 COPY . /opt/website

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+<!-- Copyright (c) Microsoft Corporation.
      SPDX-License-Identifier: MIT -->
 
 <html lang="en">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react';

--- a/src/actions/curationActions.js
+++ b/src/actions/curationActions.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { asyncActions } from './'

--- a/src/actions/definitionActions.js
+++ b/src/actions/definitionActions.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { asyncActions } from './'

--- a/src/actions/harvestActions.js
+++ b/src/actions/harvestActions.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { asyncActions } from './'

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 export function asyncActions(actionType, group = null) {

--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { ROUTE_ROOT } from '../utils/routingConstants'

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { getCurationAction } from './curationActions'

--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import 'whatwg-fetch'

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react';

--- a/src/components/Clearly.js
+++ b/src/components/Clearly.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react'

--- a/src/components/CurationEditor.js
+++ b/src/components/CurationEditor.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/CurationReview.js
+++ b/src/components/CurationReview.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/FieldGroup.js
+++ b/src/components/FieldGroup.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/GitHubCommitPicker.js
+++ b/src/components/GitHubCommitPicker.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/GitHubSelector.js
+++ b/src/components/GitHubSelector.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/HarvestQueueList.js
+++ b/src/components/HarvestQueueList.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react';

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/InfiniteList.js
+++ b/src/components/InfiniteList.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react'

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/MavenSelector.js
+++ b/src/components/MavenSelector.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/MavenVersionPicker.js
+++ b/src/components/MavenVersionPicker.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/MonacoEditorWrapper.js
+++ b/src/components/MonacoEditorWrapper.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/NpmSelector.js
+++ b/src/components/NpmSelector.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/NpmVersionPicker.js
+++ b/src/components/NpmVersionPicker.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/NuGetSelector.js
+++ b/src/components/NuGetSelector.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/PageAbout.js
+++ b/src/components/PageAbout.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/PageComponentDetails.js
+++ b/src/components/PageComponentDetails.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/PageComponents.js
+++ b/src/components/PageComponents.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/PageCurate.js
+++ b/src/components/PageCurate.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/PageHarvest.js
+++ b/src/components/PageHarvest.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/ProposePrompt.js
+++ b/src/components/ProposePrompt.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/RehydrationProvider.js
+++ b/src/components/RehydrationProvider.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // Delays loading untill the store is rehydrated

--- a/src/components/RowEntityList.js
+++ b/src/components/RowEntityList.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react'

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/SocialIcons.js
+++ b/src/components/SocialIcons.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'

--- a/src/components/TwoLineEntry.js
+++ b/src/components/TwoLineEntry.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 export { default as App } from './App'

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { createStore, applyMiddleware, compose } from 'redux'

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 body {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import React from 'react'

--- a/src/reducers/definitionReducer.js
+++ b/src/reducers/definitionReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'

--- a/src/reducers/harvestReducer.js
+++ b/src/reducers/harvestReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'

--- a/src/reducers/itemReducer.js
+++ b/src/reducers/itemReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const initialState = {

--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import * as _ from 'lodash'

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { LOGIN, LOGOUT } from '../actions/sessionActions'

--- a/src/reducers/tableReducer.js
+++ b/src/reducers/tableReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { merge, omit, keys } from 'lodash'

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'

--- a/src/reducers/valueReducer.js
+++ b/src/reducers/valueReducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 export default (name = '') => {

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // In production, we register a service worker to serve assets from local cache.

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 .App {

--- a/src/styles/_Footer.scss
+++ b/src/styles/_Footer.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 .Footer {

--- a/src/styles/_Header.scss
+++ b/src/styles/_Header.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 .navbar {

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 .List {

--- a/src/styles/_bootstrapFixes.scss
+++ b/src/styles/_bootstrapFixes.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 // modifications to the standard bootstrap styles

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 $horizontal-padding: 1rem;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* Copyright (c) Microsoft Corporation. */
 /* SPDX-License-Identifier: MIT */
 
 @import './variables';

--- a/src/utils/entitySpec.js
+++ b/src/utils/entitySpec.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 const url = require('url');

--- a/src/utils/install-monaco.js
+++ b/src/utils/install-monaco.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 // Goofy little utility used at build time to copy the monaco files from their module to

--- a/src/utils/routingConstants.js
+++ b/src/utils/routingConstants.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: MIT
 
 export const ROUTE_ABOUT= "/about"


### PR DESCRIPTION
After discussion at the TODO hackathon, it was agreed to remove
"All Rights Reserved" statements from copyright notices in order
to reduce potential confusion.