### PR TITLE
Add notification alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",
     "react-bootstrap-typeahead": "^2.3.0",
+    "react-bs-notifier": "^4.4.6",
     "react-dom": "^16.2.0",
     "react-fontawesome": "^1.6.1",
     "react-monaco-editor": "^0.13.0",

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and Others.
 // SPDX-License-Identifier: MIT
 
 import { getCurationAction } from './curationActions'
@@ -7,6 +7,9 @@ import { getHarvestOutputAction } from './harvestActions'
 
 export const UI_NAVIGATION = 'UI_NAVIGATION'
 export const UI_REDIRECT = 'UI_REDIRECT'
+
+export const UI_NOTIFICATION_NEW = 'UI_NOTIFICATION_NEW'
+export const UI_NOTIFICATION_DELETE = 'UI_NOTIFICATION_DELETE'
 
 export const UI_INSPECT_UPDATE_FILTER = 'UI_INSPECT_UPDATE_FILTER'
 export const UI_INSPECT_GET_CURATION = 'UI_INSPECT_GET_CURATION'
@@ -32,6 +35,15 @@ export function uiNavigation(navItem) {
 
 export function uiRedirect(to) {
   return { type: UI_REDIRECT, to }
+}
+
+let nextNotificationId = 0
+export function uiNotificationNew(message) {
+  return { type: UI_NOTIFICATION_NEW, message: { ...message, id: nextNotificationId++} }
+}
+
+export function uiNotificationDelete(message) {
+  return { type: UI_NOTIFICATION_DELETE, message }
 }
 
 export function uiInspectUpdateFilter(value) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,8 +1,8 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and Others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react';
-import { Header, Footer } from './'
+import { Header, Footer, NotificationList } from './'
 
 export default class App extends Component {
   render() {
@@ -14,6 +14,7 @@ export default class App extends Component {
           {children}
         </main>
         <Footer />
+        <NotificationList />
       </div>
     )
   }

--- a/src/components/NotificationList.js
+++ b/src/components/NotificationList.js
@@ -10,22 +10,32 @@ import { uiNotificationDelete } from '../actions/ui'
 class NotificationList extends Component {
 
   static propTypes = {
-    notifications: PropTypes.array
+    notifications: PropTypes.array,
+    position: PropTypes.string
   }
 
   static defaultProps = {
-    notifications: []
+    notifications: [],
+    position: 'top-right'
+  }
+
+  constructor(props) {
+    super(props)
+    this.onDismiss = this.onDismiss.bind(this)
+  }
+
+  onDismiss(message) {
+    this.props.dispatch(uiNotificationDelete(message))
   }
 
   render() {
-    const {dispatch} = this.props
+    const { position, notifications } = this.props
     return (
       <div>
         <AlertList
-          position="top-right"
-          alerts={this.props.notifications}
-          timeout={4000}
-          onDismiss={message => dispatch(uiNotificationDelete(message))}
+          position={ position }
+          alerts={ notifications }
+          onDismiss={ this.onDismiss }
           />
       </div>
     )

--- a/src/components/NotificationList.js
+++ b/src/components/NotificationList.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2017, The Linux Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { AlertList } from 'react-bs-notifier'
+import { uiNotificationDelete } from '../actions/ui'
+
+class NotificationList extends Component {
+
+  static propTypes = {
+    notifications: PropTypes.array
+  }
+
+  static defaultProps = {
+    notifications: []
+  }
+
+  render() {
+    const {dispatch} = this.props
+    return (
+      <div>
+        <AlertList
+          position="top-right"
+          alerts={this.props.notifications}
+          timeout={4000}
+          onDismiss={message => dispatch(uiNotificationDelete(message))}
+          />
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  notifications: state.ui.notifications
+})
+
+export default connect(mapStateToProps)(NotificationList)

--- a/src/components/PageHarvest.js
+++ b/src/components/PageHarvest.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and Others.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
@@ -7,7 +7,7 @@ import { Grid, Row, Col, Button, ButtonGroup } from 'react-bootstrap'
 import { ROUTE_HARVEST } from '../utils/routingConstants'
 import { harvestAction } from '../actions/harvestActions'
 import { HarvestQueueList, GitHubSelector, NpmSelector, MavenSelector, NuGetSelector, Section } from './'
-import { uiNavigation, uiHarvestUpdateQueue } from '../actions/ui'
+import { uiNavigation, uiHarvestUpdateQueue, uiNotificationNew } from '../actions/ui'
 import EntitySpec from '../utils/entitySpec'
 
 class PageHarvest extends Component {
@@ -28,6 +28,7 @@ class PageHarvest extends Component {
 
   harvestHandler(spec) {
     const { dispatch, token, queue } = this.props
+    dispatch(uiNotificationNew({ type: 'info', message: 'Harvesting started.', timeout: 5000 }))
     const requests = queue.list.map(entry => {
       return { tool: entry.tool || entry.type, coordinates: entry.toPath(), policy: entry.policy }
     })

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and Others.
 // SPDX-License-Identifier: MIT
 
 export { default as App } from './App'
@@ -18,6 +18,7 @@ export { default as Landing } from './Landing'
 export { default as MavenSelector } from './MavenSelector'
 export { default as MavenVersionPicker } from './MavenVersionPicker'
 export { default as MonacoEditorWrapper } from './MonacoEditorWrapper'
+export { default as NotificationList } from './NotificationList'
 export { default as NpmSelector } from './NpmSelector'
 export { default as NpmVersionPicker } from './NpmVersionPicker'
 export { default as NuGetSelector } from './NuGetSelector'

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation and Others.
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
 import { ROUTE_ROOT, ROUTE_CURATE, ROUTE_COMPONENTS, ROUTE_HARVEST, ROUTE_ABOUT, ROUTE_INSPECT } from '../utils/routingConstants'
 import {
-  UI_NAVIGATION, 
+  UI_NAVIGATION,
+  UI_NOTIFICATION_NEW, UI_NOTIFICATION_DELETE,
   UI_CURATE_UPDATE_FILTER, UI_CURATE_GET, UI_CURATE_GET_PROPOSED, UI_CURATE_GET_DEFINITION,UI_CURATE_DEFINITION_PREVIEW,
   UI_BROWSE_UPDATE_FILTER, UI_BROWSE_UPDATE_LIST,
   UI_HARVEST_UPDATE_FILTER, UI_HARVEST_UPDATE_QUEUE,
@@ -115,10 +116,23 @@ const harvest = (state = initialHarvest, action) => {
   }
 }
 
+const notifications = (state = [], action) => {
+  const {type, message} = action
+  switch(type) {
+    case UI_NOTIFICATION_NEW:
+      return [...state, message]
+    case UI_NOTIFICATION_DELETE:
+      return state.filter(x => x.id !== message.id)
+    default:
+      return state
+  }
+}
+
 export default combineReducers({
   navigation,
   browse,
   inspect,
   curate,
-  harvest
+  harvest,
+  notifications
 })


### PR DESCRIPTION
This adds an easy way to trigger notification alerts in the app. It's essentially a container that manages state for the [React Bootstrap Notifier](https://chadly.github.io/react-bs-notifier/). Example: to trigger a notification:

```js
import { uiNotificationNew } from '../actions/ui'
this.props.dispatch(uiNotificationNew({ type: 'info', message: 'Harvesting started.', timeout: 5000 }))
```

For all available options see https://chadly.github.io/react-bs-notifier/ 

To demonstrate usage the Harvest button triggers an "info" alert that harvesting has started. Subsequent PRs can dispatch notifications to the success/error handlers for the harvester.

![image](https://user-images.githubusercontent.com/299129/36776706-a1d7c6d0-1c1b-11e8-8242-351b5f7087fd.png)

Fixes #14 