### PR TITLE
Add Modal sub components to fix styling

### DIFF
--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -47,19 +47,28 @@ export default class ContributePrompt extends Component {
     return (
       <Modal show={this.state.show} onHide={this.close}>
         <Form>
-          <h5>Describe the changes in this curation</h5>
-          <FieldGroup
-            name="description"
-            type="text"
-            label="Description"
-            value={description || ''}
-            onChange={this.handleChange}
-            placeholder="Short description of changes. Like a commit message..."
-            maxLength={100}
-          />
-          <Button type="button" onClick={this.okHandler}>
-            OK
-          </Button>
+          <Modal.Header closeButton>
+            <Modal.Title>Describe the changes in this curation</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <FieldGroup
+              name="description"
+              type="text"
+              label="Description"
+              value={description || ''}
+              onChange={this.handleChange}
+              placeholder="Short description of changes. Like a commit message..."
+              maxLength={100}
+              componentClass="textarea"
+              rows="10"
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.close}>Cancel</Button>
+            <Button bsStyle="success" type="button" onClick={this.okHandler}>
+              OK
+            </Button>
+          </Modal.Footer>
         </Form>
       </Modal>
     )


### PR DESCRIPTION
Partially addresses #51 in terms of the styling issues. The template bit can come next. 

* Adds the missing Modal sub components to fix the padding/spacing
* Turns the text input into a textarea (10 rows)
* Adds the close icon in the modal header
* Adds a Cancel button in the form

![image](https://user-images.githubusercontent.com/299129/36957122-128880b2-1fe7-11e8-9068-4b35dd59e5da.png)
