### PR TITLE
Fix text overflow for list items

### DIFF
--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -255,7 +255,7 @@ export default class ComponentList extends React.Component {
               </p>
             </Col>
             <Col md={10}>
-              <p className="ellipsis">{sourceUrl}</p>
+              <p className="list-singleLine">{sourceUrl}</p>
             </Col>
           </Row>
           <Row>
@@ -275,9 +275,7 @@ export default class ComponentList extends React.Component {
               </p>
             </Col>
             <Col md={9}>
-              <p>
-                <span className="list-singleLine">{toolList.join(', ')}</span>
-              </p>
+              <p className="list-singleLine">{toolList.join(', ')}</p>
             </Col>
           </Row>
           <Row>
@@ -287,9 +285,7 @@ export default class ComponentList extends React.Component {
               </p>
             </Col>
             <Col md={10}>
-              <p>
-                <span className="list-singleLine">{facetsText}</span>
-              </p>
+              <p className="list-singleLine">{facetsText}</p>
             </Col>
           </Row>
         </Col>
@@ -311,9 +307,7 @@ export default class ComponentList extends React.Component {
               </p>
             </Col>
             <Col md={9}>
-              <p>
-                <span className="list-singleLine">{get(licensed, 'discovered.expressions', []).join(', ')}</span>
-              </p>
+              <p className="list-singleLine">{get(licensed, 'discovered.expressions', []).join(', ')}</p>
             </Col>
           </Row>
           <Row>
@@ -323,9 +317,7 @@ export default class ComponentList extends React.Component {
               </p>
             </Col>
             <Col md={9}>
-              <p>
-                <span className="list-singleLine">{get(licensed, 'attribution.parties', []).join(', ')}</span>
-              </p>
+              <p className="list-singleLine">{get(licensed, 'attribution.parties', []).join(', ')}</p>
             </Col>
           </Row>
           <Row>

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -148,12 +148,6 @@
   font-size: 2em;
 }
 
-.ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .about-text {
   font-size: 1.25em;
 }

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -80,7 +80,6 @@
 }
 
 .list-singleLine {
-  // width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
The ellipsis overflow rules need to be on a block-level item (`span` is inline). So I just added the class to the `p` which is a block-level item.

Signed-off-by: Mark Matyas <mmatyas@codeaurora.org>