### PR TITLE
Fix subsequent filtering after first selection

### DIFF
--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -31,8 +31,7 @@ export default class FilterBar extends Component {
   }
 
   filter(option, text) {
-    if (this.props.value) return true
-    return option.path.toLowerCase().indexOf(text.toLowerCase()) !== -1
+    return option.path.toLowerCase().includes(text.toLowerCase())
   }
 
   render() {


### PR DESCRIPTION
Fixes #109 

Not sure why this was there in the first place, so it may break something else. It may have been an attempt at maintaining the filterbar selection after navigating away. #113 should help there.