### PR TITLE
adapt to the new suggest api in service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3932,8 +3932,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/src/actions/definitionActions.js
+++ b/src/actions/definitionActions.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { asyncActions } from './'
-import { getDefinitions, getDefinition, previewDefinition, getDefinitionList } from '../api/clearlyDefined'
+import { getDefinitions, getDefinition, previewDefinition, getDefinitionSuggestions } from '../api/clearlyDefined'
 
 export const DEFINITION_LIST = 'DEFINITION_LIST'
 export const DEFINITION_BODIES = 'DEFINITION_BODIES'
@@ -29,11 +29,12 @@ export function getDefinitionsAction(token, entities) {
   }
 }
 
-export function getDefinitionListAction(token, prefix, force) {
+export function getDefinitionSuggestionsAction(token, prefix, name) {
   return dispatch => {
-    const actions = asyncActions(DEFINITION_LIST)
+    if (!prefix) return null
+    const actions = asyncActions(name)
     dispatch(actions.start())
-    return getDefinitionList(token, prefix, force).then(
+    return getDefinitionSuggestions(token, prefix).then(
       result => dispatch(actions.success(result)),
       error => dispatch(actions.error(error))
     )

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { getCurationAction } from './curationActions'
-import { getDefinitionAction, previewDefinitionAction } from './definitionActions'
+import { getDefinitionAction, previewDefinitionAction, getDefinitionSuggestionsAction } from './definitionActions'
 import { getHarvestOutputAction } from './harvestActions'
 
 export const UI_NAVIGATION = 'UI_NAVIGATION'
@@ -12,11 +12,13 @@ export const UI_NOTIFICATION_NEW = 'UI_NOTIFICATION_NEW'
 export const UI_NOTIFICATION_DELETE = 'UI_NOTIFICATION_DELETE'
 
 export const UI_INSPECT_UPDATE_FILTER = 'UI_INSPECT_UPDATE_FILTER'
+export const UI_INSPECT_UPDATE_FILTER_LIST = 'UI_INSPECT_UPDATE_FILTER_LIST'
 export const UI_INSPECT_GET_CURATION = 'UI_INSPECT_GET_CURATION'
 export const UI_INSPECT_GET_DEFINITION = 'UI_INSPECT_GET_DEFINITION'
 export const UI_INSPECT_GET_HARVESTED = 'UI_INSPECT_GET_HARVESTED'
 
 export const UI_CURATE_UPDATE_FILTER = 'UI_CURATE_UPDATE_FILTER'
+export const UI_CURATE_UPDATE_FILTER_LIST = 'UI_CURATE_UPDATE_FILTER_LIST'
 export const UI_CURATE_GET = 'UI_CURATE_GET'
 export const UI_CURATE_GET_PROPOSED = 'UI_CURATE_GET_PROPOSED'
 export const UI_CURATE_GET_DEFINITION = 'UI_CURATE_GET_DEFINITION'
@@ -24,6 +26,7 @@ export const UI_CURATE_GET_DEFINITION_PROPOSED = 'UI_CURATE_GET_DEFINITION_PROPO
 export const UI_CURATE_DEFINITION_PREVIEW = 'UI_CURATE_DEFINITION_PREVIEW'
 
 export const UI_BROWSE_UPDATE_FILTER = 'UI_BROWSE_UPDATE_FILTER'
+export const UI_BROWSE_UPDATE_FILTER_LIST = 'UI_BROWSE_UPDATE_FILTER_LIST'
 export const UI_BROWSE_UPDATE_LIST = 'UI_BROWSE_UPDATE_LIST'
 
 export const UI_HARVEST_UPDATE_FILTER = 'UI_HARVEST_UPDATE_FILTER'
@@ -50,6 +53,10 @@ export function uiInspectUpdateFilter(value) {
   return { type: UI_INSPECT_UPDATE_FILTER, value }
 }
 
+export function uiInspectUpdateFilterList(token, prefix) {
+  return getDefinitionSuggestionsAction(token, prefix, UI_INSPECT_UPDATE_FILTER_LIST)
+}
+
 export function uiInspectGetCuration(token, entity) {
   return getCurationAction(token, entity, UI_INSPECT_GET_CURATION)
 }
@@ -66,6 +73,10 @@ export function uiCurateUpdateFilter(value) {
   return { type: UI_CURATE_UPDATE_FILTER, value }
 }
 
+export function uiCurateUpdateFilterList(token, prefix) {
+  return getDefinitionSuggestionsAction(token, prefix, UI_CURATE_UPDATE_FILTER_LIST)
+}
+
 export function uiCurateGetCuration(token, entity) {
   return getCurationAction(token, entity, entity.pr ? UI_CURATE_GET_PROPOSED : UI_CURATE_GET)
 }
@@ -80,6 +91,10 @@ export function uiCurateGetDefinitionPreview(token, entity, curation) {
 
 export function uiBrowseUpdateFilter(value) {
   return { type: UI_BROWSE_UPDATE_FILTER, value }
+}
+
+export function uiBrowseUpdateFilterList(token, prefix) {
+  return getDefinitionSuggestionsAction(token, prefix, UI_BROWSE_UPDATE_FILTER_LIST)
 }
 
 export function uiBrowseUpdateList(value) {

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -3,16 +3,17 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Typeahead } from 'react-bootstrap-typeahead'
+import { AsyncTypeahead } from 'react-bootstrap-typeahead'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 
 export default class FilterBar extends Component {
   static propTypes = {
     value: PropTypes.string,
-    options: PropTypes.any,
+    options: PropTypes.any.isRequired,
     onChange: PropTypes.func,
     clearOnChange: PropTypes.bool,
-    defaultValue: PropTypes.string
+    defaultValue: PropTypes.string,
+    onSearch: PropTypes.func.isRequired
   }
 
   constructor(props) {
@@ -24,30 +25,31 @@ export default class FilterBar extends Component {
   onChange(values) {
     const { onChange, clearOnChange } = this.props
     if (values.length) {
-      onChange && onChange(values[0].path)
+      onChange && onChange(values[0])
       // timing hack to work around https://github.com/ericgio/react-bootstrap-typeahead/issues/211
       clearOnChange && setTimeout(() => this.refs.typeahead.getInstance().clear(), 0)
     }
   }
 
   filter(option, text) {
-    return option.path.toLowerCase().includes(text.toLowerCase())
+    return option.toLowerCase().includes(text.toLowerCase())
   }
 
   render() {
-    const { options, defaultValue, value } = this.props
+    const { options, defaultValue, value, onSearch } = this.props
     return (
-      <Typeahead
+      <AsyncTypeahead
         ref="typeahead"
         placeholder="Component search..."
         onChange={this.onChange}
-        options={options.transformedList}
+        options={options.list}
         isLoading={options.isFetching}
+        onSearch={onSearch}
         clearButton
         defaultInputValue={(!value && defaultValue) || ''}
-        filterBy={this.filter}
+        // filterBy={this.filter}
         labelKey="path"
-        selected={value && [{ path: value }]}
+        selected={value && [value]}
       />
     )
   }

--- a/src/components/PageCurate.js
+++ b/src/components/PageCurate.js
@@ -4,13 +4,12 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { uiCurateUpdateFilter, uiCurateGetCuration, uiCurateGetDefinition } from '../actions/ui'
-import { uiNavigation, uiNotificationNew } from '../actions/ui'
+import { uiNavigation, uiNotificationNew, uiCurateUpdateFilterList } from '../actions/ui'
 import { Grid, Row, Col } from 'react-bootstrap'
 import { CurationReview, ContributePrompt, ProposePrompt } from './'
 import { ROUTE_CURATE } from '../utils/routingConstants'
 import EntitySpec from '../utils/entitySpec'
 import { curateAction } from '../actions/curationActions'
-import { getDefinitionListAction } from '../actions/definitionActions'
 import { FilterBar, CopyUrlButton } from './'
 import { Button } from 'react-bootstrap'
 
@@ -23,14 +22,14 @@ class PageCurate extends Component {
     this.doPromptContribute = this.doPromptContribute.bind(this)
     this.doPromptPropose = this.doPromptPropose.bind(this)
     this.filterChanged = this.filterChanged.bind(this)
+    this.onSearch = this.onSearch.bind(this)
   }
 
   componentDidMount() {
-    const { dispatch, token, path, filterValue } = this.props
+    const { dispatch, path, filterValue } = this.props
     const pathToShow = path ? path : filterValue
     this.filterChanged(pathToShow)
     dispatch(uiNavigation({ to: ROUTE_CURATE }))
-    dispatch(getDefinitionListAction(token))
   }
 
   componentWillReceiveProps(newProps) {
@@ -90,6 +89,11 @@ class PageCurate extends Component {
 
   filterChanged(newFilter) {
     this.props.dispatch(uiCurateUpdateFilter(newFilter))
+  }
+
+  onSearch(value) {
+    const { dispatch, token } = this.props
+    dispatch(uiCurateUpdateFilterList(token, value))
   }
 
   gotoValue(value) {
@@ -157,6 +161,7 @@ class PageCurate extends Component {
               options={filterOptions}
               value={filterValue}
               onChange={this.filterChanged}
+              onSearch={this.onSearch}
               defaultValue={path || ''}
             />
           </Col>
@@ -182,7 +187,7 @@ function mapStateToProps(state, ownProps) {
     proposedCuration: state.ui.curate.proposedCuration,
     proposedDefinition: state.ui.curate.proposedDefinition,
     filterValue: state.ui.curate.filter,
-    filterOptions: state.definition.list
+    filterOptions: state.ui.curate.filterList
   }
 }
 export default connect(mapStateToProps)(PageCurate)

--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -5,9 +5,9 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Grid, Row, Col } from 'react-bootstrap'
 import { ROUTE_DEFINITIONS, ROUTE_INSPECT, ROUTE_CURATE } from '../utils/routingConstants'
-import { getDefinitionListAction, getDefinitionsAction } from '../actions/definitionActions'
+import { getDefinitionsAction } from '../actions/definitionActions'
 import { FilterBar, ComponentList, Section, FacetSelect } from './'
-import { uiNavigation, uiBrowseUpdateList } from '../actions/ui'
+import { uiNavigation, uiBrowseUpdateList, uiBrowseUpdateFilterList } from '../actions/ui'
 import EntitySpec from '../utils/entitySpec'
 
 const defaultFacets = [{ value: 'core', label: 'Core' }]
@@ -17,6 +17,7 @@ class PageDefinitions extends Component {
     super(props)
     this.state = { activeFacets: defaultFacets.map(x => x.value) }
     this.onAddComponent = this.onAddComponent.bind(this)
+    this.onSearch = this.onSearch.bind(this)
     this.onInspect = this.onInspect.bind(this)
     this.onCurate = this.onCurate.bind(this)
     this.onRemoveComponent = this.onRemoveComponent.bind(this)
@@ -25,9 +26,8 @@ class PageDefinitions extends Component {
   }
 
   componentDidMount() {
-    const { dispatch, token } = this.props
+    const { dispatch } = this.props
     dispatch(uiNavigation({ to: ROUTE_DEFINITIONS }))
-    dispatch(getDefinitionListAction(token))
   }
 
   onAddComponent(value, after = null) {
@@ -37,6 +37,11 @@ class PageDefinitions extends Component {
     component.definition = !!definitions.entries[path]
     !component.definition && dispatch(getDefinitionsAction(token, [path]))
     dispatch(uiBrowseUpdateList({ add: component }))
+  }
+
+  onSearch(value) {
+    const { dispatch, token } = this.props
+    dispatch(uiBrowseUpdateFilterList(token, value))
   }
 
   onCurate(component) {
@@ -76,7 +81,7 @@ class PageDefinitions extends Component {
             <FacetSelect name="facets" onChange={this.facetChange} defaultFacets={defaultFacets} />
           </Col>
           <Col md={7}>
-            <FilterBar options={filterOptions} onChange={this.onAddComponent} clearOnChange />
+            <FilterBar options={filterOptions} onChange={this.onAddComponent} onSearch={this.onSearch} clearOnChange />
           </Col>
         </Row>
         <Section name={'Available definitions'}>
@@ -105,8 +110,8 @@ function mapStateToProps(state, ownProps) {
   return {
     token: state.session.token,
     filterValue: state.ui.browse.filter,
+    filterOptions: state.ui.browse.filterList,
     components: state.ui.browse.componentList,
-    filterOptions: state.definition.list,
     definitions: state.definition.bodies
   }
 }

--- a/src/components/PageInspect.js
+++ b/src/components/PageInspect.js
@@ -4,8 +4,12 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Button, Grid, Row, Col } from 'react-bootstrap'
-import { getDefinitionListAction } from '../actions/definitionActions'
-import { uiInspectGetCuration, uiInspectGetHarvested, uiInspectGetDefinition } from '../actions/ui'
+import {
+  uiInspectGetCuration,
+  uiInspectGetHarvested,
+  uiInspectGetDefinition,
+  uiInspectUpdateFilterList
+} from '../actions/ui'
 import { uiNavigation, uiInspectUpdateFilter } from '../actions/ui'
 import { FilterBar, MonacoEditorWrapper, Section, CopyUrlButton } from './'
 import EntitySpec from '../utils/entitySpec'
@@ -16,16 +20,16 @@ class PageInspect extends Component {
     super(props)
     this.state = {}
     this.filterChanged = this.filterChanged.bind(this)
+    this.onSearch = this.onSearch.bind(this)
     this.editorDidMount = this.editorDidMount.bind(this)
     this.addCuration = this.addCuration.bind(this)
   }
 
   componentDidMount() {
-    const { dispatch, token, path, filterValue } = this.props
+    const { dispatch, path, filterValue } = this.props
     const pathToShow = path ? path : filterValue
     this.handleNewSpec(pathToShow)
     dispatch(uiNavigation({ to: ROUTE_INSPECT }))
-    dispatch(getDefinitionListAction(token))
   }
 
   componentWillReceiveProps(newProps) {
@@ -57,6 +61,11 @@ class PageInspect extends Component {
 
   filterChanged(newFilter) {
     this.props.dispatch(uiInspectUpdateFilter(newFilter))
+  }
+
+  onSearch(value) {
+    const { dispatch, token } = this.props
+    dispatch(uiInspectUpdateFilterList(token, value))
   }
 
   gotoValue(value) {
@@ -135,6 +144,7 @@ class PageInspect extends Component {
               options={filterOptions}
               value={filterValue}
               onChange={this.filterChanged}
+              onSearch={this.onSearch}
               defaultValue={path || ''}
             />
           </Col>
@@ -157,7 +167,7 @@ function mapStateToProps(state, ownProps) {
     token: state.session.token,
     path: ownProps.location.pathname.slice(ownProps.match.url.length + 1),
     filterValue: state.ui.inspect.filter,
-    filterOptions: state.definition.list,
+    filterOptions: state.ui.inspect.filterList,
     definition: state.ui.inspect.definition,
     curation: state.ui.inspect.curation,
     harvest: state.ui.inspect.harvested

--- a/src/reducers/definitionReducer.js
+++ b/src/reducers/definitionReducer.js
@@ -2,13 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { DEFINITION_BODIES, DEFINITION_LIST } from '../actions/definitionActions'
-import listReducer from './listReducer'
+import { DEFINITION_BODIES } from '../actions/definitionActions'
 import tableReducer from './tableReducer'
 
 export default combineReducers({
-  list: new listReducer(DEFINITION_LIST, item => {
-    return { path: item }
-  }),
   bodies: tableReducer(DEFINITION_BODIES)
 })

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -8,21 +8,24 @@ import {
   UI_NOTIFICATION_NEW,
   UI_NOTIFICATION_DELETE,
   UI_CURATE_UPDATE_FILTER,
+  UI_CURATE_UPDATE_FILTER_LIST,
   UI_CURATE_GET,
   UI_CURATE_GET_PROPOSED,
   UI_CURATE_GET_DEFINITION,
   UI_CURATE_GET_DEFINITION_PROPOSED,
   UI_CURATE_DEFINITION_PREVIEW,
   UI_BROWSE_UPDATE_FILTER,
+  UI_BROWSE_UPDATE_FILTER_LIST,
   UI_BROWSE_UPDATE_LIST,
   UI_HARVEST_UPDATE_FILTER,
   UI_HARVEST_UPDATE_QUEUE,
   UI_INSPECT_UPDATE_FILTER,
+  UI_INSPECT_UPDATE_FILTER_LIST,
   UI_INSPECT_GET_CURATION,
   UI_INSPECT_GET_DEFINITION,
   UI_INSPECT_GET_HARVESTED
 } from '../actions/ui'
-import listReducer, { initialState as initialListState } from './listReducer'
+import listReducer from './listReducer'
 import { isEqual } from 'lodash'
 import valueReducer from './valueReducer'
 import itemReducer from './itemReducer'
@@ -82,6 +85,7 @@ const navigation = (state = initialStateNavigation, action) => {
 
 const curate = combineReducers({
   filter: new valueReducer(UI_CURATE_UPDATE_FILTER),
+  filterList: new listReducer(UI_CURATE_UPDATE_FILTER_LIST),
   currentCuration: new itemReducer(UI_CURATE_GET),
   proposedCuration: new itemReducer(UI_CURATE_GET_PROPOSED),
   currentDefinition: new itemReducer(UI_CURATE_GET_DEFINITION),
@@ -91,36 +95,22 @@ const curate = combineReducers({
 
 const inspect = combineReducers({
   filter: new valueReducer(UI_INSPECT_UPDATE_FILTER),
+  filterList: new listReducer(UI_INSPECT_UPDATE_FILTER_LIST),
   definition: new itemReducer(UI_INSPECT_GET_DEFINITION, item => yaml.safeDump(item, { sortKeys: true })),
   curation: new itemReducer(UI_INSPECT_GET_CURATION, item => yaml.safeDump(item, { sortKeys: true })),
   harvested: new itemReducer(UI_INSPECT_GET_HARVESTED, item => JSON.stringify(item, null, 2))
 })
 
-const componentList = listReducer(UI_BROWSE_UPDATE_LIST, null, isEqual)
-const initialBrowse = { filter: null, componentList: initialListState }
-const browse = (state = initialBrowse, action) => {
-  switch (action.type) {
-    case UI_BROWSE_UPDATE_FILTER:
-      return { ...state, filter: action.value }
-    case UI_BROWSE_UPDATE_LIST:
-      return { ...state, componentList: componentList(state.componentList, action) }
-    default:
-      return state
-  }
-}
+const browse = combineReducers({
+  filter: new valueReducer(UI_BROWSE_UPDATE_FILTER),
+  filterList: new listReducer(UI_BROWSE_UPDATE_FILTER_LIST),
+  componentList: new listReducer(UI_BROWSE_UPDATE_LIST, null, isEqual)
+})
 
-const harvestQueue = listReducer(UI_HARVEST_UPDATE_QUEUE, null, isEqual)
-const initialHarvest = { filter: null, requestQueue: initialListState }
-const harvest = (state = initialHarvest, action) => {
-  switch (action.type) {
-    case UI_HARVEST_UPDATE_FILTER:
-      return { ...state, filter: action.value }
-    case UI_HARVEST_UPDATE_QUEUE:
-      return { ...state, requestQueue: harvestQueue(state.requestQueue, action) }
-    default:
-      return state
-  }
-}
+const harvest = combineReducers({
+  filter: new valueReducer(UI_HARVEST_UPDATE_FILTER),
+  requestQueue: new listReducer(UI_HARVEST_UPDATE_QUEUE, null, isEqual)
+})
 
 const notifications = (state = [], action) => {
   const { type, message } = action


### PR DESCRIPTION
On the service the "list all components" API was not scaling. instead we implemented an explicit "suggest" API for exactly the auto-complete scenario. This PR adapts all uses of getComponentList to use the suggest API.

Note that deployment of this needs to be coupled with the deployment of https://github.com/clearlydefined/service/pull/129 where the new api is added