### PR TITLE
File facet tagging component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "deep-diff": "^0.3.8",
     "lodash": "^4.17.4",
     "moment": "^2.20.1",
+    "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-bootstrap": "^0.31.5",
     "react-bootstrap-typeahead": "^2.3.0",

--- a/src/components/FileTagger.js
+++ b/src/components/FileTagger.js
@@ -30,7 +30,7 @@ export default class FileTagger extends Component {
     })
 
     return (
-      <Table hover condensed>
+      <Table className="file-tagger" condensed>
         <tbody>
           <FileTaggerRow key="root" entry={tree} fileFacets={fileFacets} onFacetSelect={this.changeFacet} />
         </tbody>

--- a/src/components/FileTagger.js
+++ b/src/components/FileTagger.js
@@ -1,0 +1,90 @@
+// Copyright (c) Amazon.com, Inc. and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Table } from 'react-bootstrap'
+import FileTaggerRow from './FileTaggerRow'
+
+export default class FileTagger extends Component {
+  static propTypes = {
+    fileList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    facetMap: PropTypes.objectOf(PropTypes.string).isRequired,
+    onFacetMapChange: PropTypes.func.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.changeFacet = this.changeFacet.bind(this)
+    this.state = {
+      tree: pathsToTree(props.fileList)
+    }
+  }
+
+  render() {
+    const { facetMap } = this.props
+    const { tree } = this.state
+
+    const fileFacets = Object.entries(facetMap).map(([filepath, facet]) => {
+      return [filepath.split('/'), facet]
+    })
+
+    return (
+      <Table hover condensed>
+        <tbody>
+          <FileTaggerRow key="root" entry={tree} fileFacets={fileFacets} onFacetSelect={this.changeFacet} />
+        </tbody>
+      </Table>
+    )
+  }
+
+  changeFacet(node, facet) {
+    const { onFacetMapChange, facetMap } = this.props
+    const nodePath = node.path.join('/')
+
+    // erase a facet
+    if (!facet) {
+      const newMap = { ...facetMap }
+      delete newMap[nodePath]
+      onFacetMapChange(newMap)
+      return
+    }
+
+    // update/add a facet
+    onFacetMapChange({
+      ...facetMap,
+      [node.path.join('/')]: facet
+    })
+  }
+}
+
+function pathsToTree(paths) {
+  const root = emptyNode('root')
+  for (const path of paths) {
+    buildPath(root, path.split('/'))
+  }
+  return root
+}
+
+function buildPath(base, parts, i = 0) {
+  if (i === parts.length) {
+    return
+  }
+
+  const item = parts[i]
+  let child = base.children[item]
+  if (!child) {
+    child = emptyNode(item)
+    child.path = parts.slice(0, i + 1)
+    base.children[item] = child
+  }
+  buildPath(child, parts, i + 1)
+}
+
+function emptyNode(name) {
+  return {
+    name,
+    path: [],
+    children: {}
+  }
+}

--- a/src/components/FileTaggerRow.js
+++ b/src/components/FileTaggerRow.js
@@ -1,0 +1,109 @@
+// Copyright (c) Amazon.com, Inc. and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Grid, Row, Col, Table } from 'react-bootstrap'
+import { uiNavigation } from '../actions/ui'
+
+const Facets = {
+  core: {},
+  data: { backgroundColor: '#cfb7ff' },
+  dev: { backgroundColor: '#fffa9e' },
+  doc: { backgroundColor: '#9ee8ff' },
+  examples: { backgroundColor: '#9effa7' },
+  tests: { backgroundColor: '#ff9e9e' }
+}
+
+export default class FileTaggerRow extends Component {
+  constructor(props) {
+    super(props)
+    this.toggle = this.toggle.bind(this)
+    this.showFacets = this.showFacets.bind(this)
+    this.hideFacets = this.hideFacets.bind(this)
+    this.facetClicked = this.facetClicked.bind(this)
+    this.state = {
+      expanded: false,
+      showFacets: false
+    }
+  }
+
+  render() {
+    const { entry, depth, facet, onFacetSelect } = this.props
+    const { expanded, showFacets } = this.state
+    const hasChildren = Object.keys(entry.children).length > 0
+    const fullPath = entry.path.join('/')
+    return (
+      <React.Fragment>
+        <tr key={fullPath} onMouseOver={this.showFacets} onMouseLeave={this.hideFacets} style={{...Facets[facet]}}>
+          <td style={{ paddingLeft: `${15 * depth}px`, cursor: hasChildren ? 'pointer' : undefined }} onClick={this.toggle}>
+            <div style={{ display: 'inline-block', width: '15px' }}>
+              {hasChildren && <strong>{expanded ? '-' : '+'}</strong>}
+            </div>
+            {entry.name} <small>{entry.path.join('/')}</small>
+          </td>
+          <td style={{ width: '350px', fontSize: '0.7em', textAlign: 'right' }}>
+            {showFacets && (
+              <div>
+                {Object.keys(Facets).map(f => (
+                  <div
+                    style={{
+                      display: 'inline-block',
+                      border: '1px solid #ccc',
+                      padding: '2px 4px',
+                      marginRight: '4px',
+                      cursor: 'pointer',
+                      ...Facets[f]
+                    }}
+                    onClick={() => this.facetClicked(f)}
+                  >
+                    {f}
+                  </div>
+                ))}
+              </div>
+            )}
+          </td>
+        </tr>
+        {expanded &&
+          Object.entries(entry.children).map(([name, child]) => (
+            <FileTaggerRow key={name} entry={child} depth={depth + 1} onFacetSelect={onFacetSelect} />
+          ))}
+      </React.Fragment>
+    )
+  }
+
+  toggle() {
+    this.setState({ expanded: !this.state.expanded })
+  }
+
+  showFacets() {
+    if (this.state.showFacets) {
+      return
+    }
+    this.setState({ showFacets: true })
+  }
+
+  hideFacets(event) {
+    this.setState({ showFacets: false })
+  }
+
+  facetClicked(facet) {
+    const { entry, onFacetSelect } = this.props;
+    onFacetSelect(entry, facet)
+  }
+}
+
+/**
+ * Check whether `path` is contained in parent/self path `parent`.
+ *
+ * Both are arrays of strings. Parent should be a subset of path starting at
+ * index 0.
+ */
+function inPath(path, parent) {
+  for (let i = 0; i < parent.length; i++) {
+    if (path[i] !== parent[i]) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/components/FileTaggerRow.js
+++ b/src/components/FileTaggerRow.js
@@ -1,23 +1,30 @@
 // Copyright (c) Amazon.com, Inc. and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
-import { Grid, Row, Col, Table } from 'react-bootstrap'
-import { uiNavigation } from '../actions/ui'
 
 const Facets = {
   core: { backgroundColor: '#ffffff' },
-  data: { backgroundColor: '#cfb7ff' },
+  data: { backgroundColor: '#d4bfff' },
   dev: { backgroundColor: '#fffa9e' },
   doc: { backgroundColor: '#9ee8ff' },
   examples: { backgroundColor: '#9effa7' },
-  tests: { backgroundColor: '#ff9e9e' }
+  tests: { backgroundColor: '#ffdac1' }
 }
 
 export default class FileTaggerRow extends Component {
+  static propTypes = {
+    entry: PropTypes.object.isRequired,
+    fileFacets: PropTypes.objectOf(PropTypes.string).isRequired,
+    onFacetSelect: PropTypes.func.isRequired,
+    depth: PropTypes.number,
+    parentFacet: PropTypes.string
+  }
+
   static defaultProps = {
-    depth: -1
+    depth: -1,
+    parentFacet: 'core'
   }
 
   constructor(props) {
@@ -33,7 +40,7 @@ export default class FileTaggerRow extends Component {
   }
 
   render() {
-    const { entry, depth, fileFacets, onFacetSelect } = this.props
+    const { entry, depth } = this.props
     const { expanded, showFacets } = this.state
 
     // root node shouldn't itself be rendered
@@ -61,7 +68,7 @@ export default class FileTaggerRow extends Component {
             <div style={{ display: 'inline-block', width: '15px' }}>
               {hasChildren && <strong>{expanded ? '-' : '+'}</strong>}
             </div>
-            {entry.name} <small>{entry.path.join('/')}</small>
+            {entry.name}
           </td>
           <td style={{ width: '350px', fontSize: '0.7em', textAlign: 'right' }}>
             {showFacets ? this.renderFacetPicker() : appliedFacet}

--- a/src/components/FileTaggerRow.js
+++ b/src/components/FileTaggerRow.js
@@ -4,14 +4,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-const Facets = {
-  core: { backgroundColor: '#ffffff' },
-  data: { backgroundColor: '#d4bfff' },
-  dev: { backgroundColor: '#fffa9e' },
-  doc: { backgroundColor: '#9ee8ff' },
-  examples: { backgroundColor: '#9effa7' },
-  tests: { backgroundColor: '#ffdac1' }
-}
+const FACETS = ['core', 'data', 'dev', 'doc', 'examples', 'tests']
 
 export default class FileTaggerRow extends Component {
   static propTypes = {
@@ -59,18 +52,18 @@ export default class FileTaggerRow extends Component {
           key={fullPath}
           onMouseOver={this.showFacets}
           onMouseLeave={this.hideFacets}
-          style={{ ...Facets[appliedFacet] }}
+          className={`facet-${appliedFacet}`}
         >
           <td
             style={{ paddingLeft: `${15 * depth}px`, cursor: hasChildren ? 'pointer' : undefined }}
             onClick={this.toggle}
           >
-            <div style={{ display: 'inline-block', width: '15px' }}>
+            <div className="file-tagger-expander">
               {hasChildren && <strong>{expanded ? '-' : '+'}</strong>}
             </div>
             {entry.name}
           </td>
-          <td style={{ width: '350px', fontSize: '0.7em', textAlign: 'right' }}>
+          <td className="file-tagger-facets">
             {showFacets ? this.renderFacetPicker() : appliedFacet}
           </td>
         </tr>
@@ -96,17 +89,10 @@ export default class FileTaggerRow extends Component {
   renderFacetPicker() {
     return (
       <div>
-        {Object.keys(Facets).map(f => (
+        {FACETS.map(f => (
           <div
             key={f}
-            style={{
-              display: 'inline-block',
-              border: '1px solid #ccc',
-              padding: '2px 4px',
-              marginRight: '4px',
-              cursor: 'pointer',
-              ...Facets[f]
-            }}
+            className={`file-tagger-facet facet-${f}`}
             onClick={() => this.facetClicked(f)}
           >
             {f}

--- a/src/components/PageFileTaggerTest.js
+++ b/src/components/PageFileTaggerTest.js
@@ -2,71 +2,41 @@
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
-import { Grid, Row, Col, Table } from 'react-bootstrap'
-import FileTaggerRow from './FileTaggerRow'
+import { Grid, Row, Col } from 'react-bootstrap'
+import FileTagger from './FileTagger';
 
 export default class PageFileTaggerTest extends Component {
   constructor(props) {
     super(props)
-    this.changeFacet = this.changeFacet.bind(this)
+    this.onFacetMapChange = this.onFacetMapChange.bind(this)
     this.state = {
-      tree: pathsToTree(files),
       facetMap: facetMap
     }
   }
 
   render() {
-    const { tree, facetMap } = this.state
-
-    const fileFacets = Object.entries(facetMap).map(([filepath, facet]) => {
-      return [filepath.split('/'), facet]
-    })
-
+    const { facetMap } = this.state
     return (
       <Grid className="main-container">
         <Row>
           <Col md={12}>
-            <Table hover condensed>
-              <tbody>
-                <FileTaggerRow
-                  key="root"
-                  entry={tree}
-                  fileFacets={fileFacets}
-                  onFacetSelect={this.changeFacet}
-                />
-              </tbody>
-            </Table>
+            <FileTagger fileList={files} facetMap={facetMap} onFacetMapChange={this.onFacetMapChange} />
 
             <h4>debug stuff</h4>
-            <textarea readOnly className="form-control" value={JSON.stringify(this.state.facetMap, null, 2)} rows={10} />
-            <textarea readOnly className="form-control" value={JSON.stringify(this.state.tree, null, 2)} rows={15} />
+            <textarea
+              readOnly
+              className="form-control"
+              value={JSON.stringify(this.state.facetMap, null, 2)}
+              rows={10}
+            />
           </Col>
         </Row>
       </Grid>
     )
   }
 
-  changeFacet(node, facet) {
-    const nodePath = node.path.join('/')
-
-    // erase a facet
-    if (!facet) {
-      const newMap = {...this.state.facetMap}
-      delete newMap[nodePath]
-      this.setState({
-        facetMap: newMap
-      })
-      return
-    }
-
-    // update/add a facet
-    this.setState({
-      facetMap: {
-        ...this.state.facetMap,
-        [node.path.join('/')]: facet
-      }
-    })
+  onFacetMapChange(facetMap) {
+    this.setState({facetMap})
   }
 }
 
@@ -81,34 +51,3 @@ const files = [
   'LICENSE'
 ]
 const facetMap = { 'src/examples': 'examples', test: 'tests', 'src/examples/DOCS.txt': 'doc' }
-
-function pathsToTree(paths) {
-  const root = emptyNode('root')
-  for (const path of paths) {
-    buildPath(root, path.split('/'))
-  }
-  return root
-}
-
-function buildPath(base, parts, i = 0) {
-  if (i == parts.length) {
-    return
-  }
-
-  const item = parts[i]
-  let child = base.children[item]
-  if (!child) {
-    child = emptyNode(item)
-    child.path = parts.slice(0, i + 1)
-    base.children[item] = child
-  }
-  buildPath(child, parts, i + 1)
-}
-
-function emptyNode(name) {
-  return {
-    name,
-    path: [],
-    children: {}
-  }
-}

--- a/src/components/PageFileTaggerTest.js
+++ b/src/components/PageFileTaggerTest.js
@@ -1,0 +1,84 @@
+// Copyright (c) Amazon.com, Inc. and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Grid, Row, Col, Table } from 'react-bootstrap'
+import FileTaggerRow from './FileTaggerRow'
+
+export default class PageFileTaggerTest extends Component {
+  constructor(props) {
+    super(props)
+    this.changeFacet = this.changeFacet.bind(this)
+    this.state = {
+      tree: pathsToTree(files),
+      facetMap: facetMap
+    }
+  }
+
+  render() {
+    const { tree } = this.state
+    return (
+      <Grid className="main-container">
+        <Row>
+          <Col md={12}>
+            <Table hover condensed>
+              <tbody>
+                <FileTaggerRow key="root" entry={tree} depth={0} onFacetSelect={this.changeFacet} />
+              </tbody>
+            </Table>
+
+            <textarea className="form-control" value={JSON.stringify(this.state.facetMap, null, 2)} rows={10} />
+            <textarea className="form-control" value={JSON.stringify(this.state.tree, null, 2)} rows={15}/>
+          </Col>
+        </Row>
+      </Grid>
+    )
+  }
+
+  changeFacet(node, facet) {
+    const nodePath = node.path.join('/')
+    this.setState({
+      facetMap: {
+        ...this.state.facetMap,
+        [node.path.join('/')]: facet
+      }
+    })
+  }
+}
+
+
+const files = ['src', 'src/examples', 'src/examples/blah.txt', 'src/examples/DOCS.txt', 'src/foo.c', 'test', 'test/bar.rs', 'LICENSE']
+const facetMap = {'src/examples': 'examples', 'test': 'tests', 'src/examples/DOCS.txt': 'doc'}
+
+function pathsToTree(paths) {
+  const root = emptyNode('root')
+  for (const path of paths) {
+    buildPath(root, path.split('/'))
+  }
+  return root
+}
+
+function buildPath(base, parts, i = 0) {
+  if (i == parts.length) {
+    return
+  }
+
+  const item = parts[i]
+  let child = base.children[item]
+  if (!child) {
+    child = emptyNode(item)
+    child.path = parts.slice(0, i + 1)
+    base.children[item] = child
+  }
+  buildPath(child, parts, i + 1)
+}
+
+function emptyNode(name) {
+  return {
+    name,
+    path: [],
+    children: {},
+  }
+}
+

--- a/src/components/PageFileTaggerTest.js
+++ b/src/components/PageFileTaggerTest.js
@@ -17,19 +17,30 @@ export default class PageFileTaggerTest extends Component {
   }
 
   render() {
-    const { tree } = this.state
+    const { tree, facetMap } = this.state
+
+    const fileFacets = Object.entries(facetMap).map(([filepath, facet]) => {
+      return [filepath.split('/'), facet]
+    })
+
     return (
       <Grid className="main-container">
         <Row>
           <Col md={12}>
             <Table hover condensed>
               <tbody>
-                <FileTaggerRow key="root" entry={tree} depth={0} onFacetSelect={this.changeFacet} />
+                <FileTaggerRow
+                  key="root"
+                  entry={tree}
+                  fileFacets={fileFacets}
+                  onFacetSelect={this.changeFacet}
+                />
               </tbody>
             </Table>
 
-            <textarea className="form-control" value={JSON.stringify(this.state.facetMap, null, 2)} rows={10} />
-            <textarea className="form-control" value={JSON.stringify(this.state.tree, null, 2)} rows={15}/>
+            <h4>debug stuff</h4>
+            <textarea readOnly className="form-control" value={JSON.stringify(this.state.facetMap, null, 2)} rows={10} />
+            <textarea readOnly className="form-control" value={JSON.stringify(this.state.tree, null, 2)} rows={15} />
           </Col>
         </Row>
       </Grid>
@@ -38,6 +49,18 @@ export default class PageFileTaggerTest extends Component {
 
   changeFacet(node, facet) {
     const nodePath = node.path.join('/')
+
+    // erase a facet
+    if (!facet) {
+      const newMap = {...this.state.facetMap}
+      delete newMap[nodePath]
+      this.setState({
+        facetMap: newMap
+      })
+      return
+    }
+
+    // update/add a facet
     this.setState({
       facetMap: {
         ...this.state.facetMap,
@@ -47,9 +70,17 @@ export default class PageFileTaggerTest extends Component {
   }
 }
 
-
-const files = ['src', 'src/examples', 'src/examples/blah.txt', 'src/examples/DOCS.txt', 'src/foo.c', 'test', 'test/bar.rs', 'LICENSE']
-const facetMap = {'src/examples': 'examples', 'test': 'tests', 'src/examples/DOCS.txt': 'doc'}
+const files = [
+  'src',
+  'src/examples',
+  'src/examples/blah.txt',
+  'src/examples/DOCS.txt',
+  'src/foo.c',
+  'test',
+  'test/bar.rs',
+  'LICENSE'
+]
+const facetMap = { 'src/examples': 'examples', test: 'tests', 'src/examples/DOCS.txt': 'doc' }
 
 function pathsToTree(paths) {
   const root = emptyNode('root')
@@ -78,7 +109,6 @@ function emptyNode(name) {
   return {
     name,
     path: [],
-    children: {},
+    children: {}
   }
 }
-

--- a/src/components/RehydrationProvider.js
+++ b/src/components/RehydrationProvider.js
@@ -19,6 +19,7 @@ import { App, PageLanding, PageCurate, PageDefinitions, PageInspect, PageHarvest
 import { omit } from 'lodash'
 import PageAbout from './PageAbout'
 import withTracker from '../utils/withTracker'
+import PageFileTaggerTest from './PageFileTaggerTest'
 
 const store = configureStore()
 
@@ -50,6 +51,7 @@ export default class RehydrationDelayedProvider extends Component {
         <Router>
           <App className="App">
             <Switch>
+              <Route path={'/file-tagger-test'} component={withTracker(PageFileTaggerTest)} />
               <Route path={ROUTE_DEFINITIONS} component={withTracker(PageDefinitions)} />
               <Route path={ROUTE_INSPECT} component={withTracker(PageInspect)} />
               <Route path={ROUTE_CURATE} component={withTracker(PageCurate)} />

--- a/src/styles/_FileTagger.scss
+++ b/src/styles/_FileTagger.scss
@@ -1,0 +1,43 @@
+/* Copyright (c) Amazon.com, Inc. and others. Licensed under the MIT license. */
+/* SPDX-License-Identifier: MIT */
+
+.file-tagger {
+  tr {
+    .file-tagger-expander {
+      display: inline-block;
+      width: 15px;
+    }
+
+    .file-tagger-facets {
+      width: 350px;
+      font-size: 0.7em;
+      text-align: right;
+
+      .file-tagger-facet {
+        display: inline-block;
+        border: 1px solid #cccccc;
+        padding: 2px 4px;
+        margin-right: 4px;
+        cursor: pointer;
+      }
+    }
+  }
+  .facet-core {
+    background-color: #ffffff;
+  }
+  .facet-data {
+    background-color: #d4bfff;
+  }
+  .facet-dev {
+    background-color: #fffa9e;
+  }
+  .facet-doc {
+    background-color: #9ee8ff;
+  }
+  .facet-examples {
+    background-color: #9effa7;
+  }
+  .facet-tests {
+    background-color: #ffdac1;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -46,3 +46,4 @@ main {
 @import './Header.scss';
 @import './Footer.scss';
 @import './List.scss';
+@import './FileTagger.scss';


### PR DESCRIPTION
This implements a file tagging/picking component we discussed during the weekly meeting.

If you run this, you'll find a little demo at http://localhost:3000/file-tagger-test to play around with. That can be deleted at any time, either for this PR or later. The key component to use is `FileTagger` -- it takes a list of filenames, a map of file paths to facets (`facetMap`), and a callback. The callback is a change notification for `facetMap`.

This component does its best to elide duplicate information; e.g. if a child has the same facet as its parent it will only list the parent.

Here's a little video in action if you don't want to fire this all up: https://streamable.com/2zjpa