### PR TITLE
add support for dropping package-lock.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3952,8 +3952,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -46,27 +46,53 @@ class PageDefinitions extends Component {
     dispatch(uiBrowseUpdateList({ add: component }))
   }
 
-  onDrop(acceptedFile, rejectedFiles) {
+  onDrop(acceptedFiles, rejectedFiles) {
     const { dispatch, token, definitions } = this.props
-    acceptedFile.forEach(file => {
-      const reader = new FileReader();
+    dispatch(uiNotificationNew({ type: 'info', message: 'Loading component list from file(s)', timeout: 5000 }))
+    acceptedFiles.forEach(file => {
+      const reader = new FileReader()
       reader.onload = () => {
-        const components = JSON.parse(reader.result);
-        if (components.coordinates) {
-          components.coordinates.forEach(component => {
-            const spec = EntitySpec.validateAndCreate(component)
-            if (spec) {
-              const path = spec.toPath()
-              !definitions.entries[path] && dispatch(getDefinitionsAction(token, [path]))
-              dispatch(uiBrowseUpdateList({ add: spec }))
-            }
-          })
-        } else {
-          dispatch(uiNotificationNew({ type: 'info', message: 'Invalid file.', timeout: 5000 }))
+        const listSpec = this.loadListSpec(reader.result, file)
+        if (typeof listSpec === 'string') {
+          const message = `Invalid component list file: ${listSpec}`
+          return dispatch(uiNotificationNew({ type: 'info', message, timeout: 5000 }))
         }
-      };
+        listSpec.coordinates.forEach(component => {
+          // TODO figure a way to add these in bulk. One by one will be painful for large lists
+          const spec = EntitySpec.validateAndCreate(component)
+          if (spec) {
+            const path = spec.toPath()
+            !definitions.entries[path] && dispatch(getDefinitionsAction(token, [path]))
+            dispatch(uiBrowseUpdateList({ add: spec }))
+          }
+        })
+      }
       reader.readAsBinaryString(file)
     })
+  }
+
+  loadListSpec(content, file) {
+    try {
+      const object = JSON.parse(content)
+      if (file.name.toLowerCase() === 'package-lock.json') return this.loadPackageLockFile(object.dependencies)
+      if (object.coordinates) return object
+      return 'No component coordinates found'
+    } catch (e) {
+      return e.message
+    }
+  }
+
+  loadPackageLockFile(dependencies) {
+    const coordinates = []
+    for (const dependency in dependencies) {
+      let [namespace, name] = dependency.split('/')
+      if (!name) {
+        name = namespace
+        namespace = null
+      }
+      coordinates.push({ type: 'npm', provider: 'npmjs', namespace, name, revision: dependencies[dependency].version })
+    }
+    return { coordinates }
   }
 
   onSearch(value) {
@@ -117,15 +143,17 @@ class PageDefinitions extends Component {
     const { components } = this.props
     const spec = this.buildSaveSpec(components.list)
     const fileObject = { filter: null, sortBy: null, coordinates: spec }
-    const file = new File([JSON.stringify(fileObject, null, 2)], "components.json");
-    saveAs(file);
+    const file = new File([JSON.stringify(fileObject, null, 2)], 'components.json')
+    saveAs(file)
   }
 
   buildContributeSpec(list) {
     return list.reduce((result, component) => {
       if (!this.hasChange(component)) return result
       const coord = EntitySpec.asRevisionless(component)
-      const patch = find(result, p => { return EntitySpec.isEquivalent(p.coordinates, coord) })
+      const patch = find(result, p => {
+        return EntitySpec.isEquivalent(p.coordinates, coord)
+      })
       const revisionNumber = component.revision
       const patchChanges = Object.getOwnPropertyNames(component.changes).reduce((result, change) => {
         set(result, change, component.changes[change])
@@ -165,7 +193,12 @@ class PageDefinitions extends Component {
   renderContributeButton() {
     return (
       <div>
-        <Button bsStyle="success" className="pull-right" disabled={!this.hasChanges()} onClick={this.doPromptContribute}>
+        <Button
+          bsStyle="success"
+          className="pull-right"
+          disabled={!this.hasChanges()}
+          onClick={this.doPromptContribute}
+        >
           Contribute
         </Button>
         <Button bsStyle="success" disabled={!this.hasComponents()} onClick={this.doSave}>
@@ -190,7 +223,7 @@ class PageDefinitions extends Component {
           </Col>
         </Row>
         <Section name={'Available definitions'} actionButton={this.renderContributeButton()}>
-          <Dropzone disableClick onDrop={this.onDrop} style={{ position: "relative" }}>
+          <Dropzone disableClick onDrop={this.onDrop} style={{ position: 'relative' }}>
             <div className="section-body">
               <ComponentList
                 list={components}


### PR DESCRIPTION
Implement the feature in #137 .

Note that this should not be merged/used until we address the caching and batching work in #138, #139 and #140. Otherwise we'll DOS shields.io and ourselves.