### PR TITLE
fix various warnings and errors

### DIFF
--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Grid, Row, Col, Button, DropdownButton, MenuItem, Navbar, Nav, NavItem, NavDropdown } from 'react-bootstrap'
+import { Grid, Row, Col, Button, DropdownButton, MenuItem } from 'react-bootstrap'
 import { ROUTE_DEFINITIONS, ROUTE_INSPECT, ROUTE_CURATE } from '../utils/routingConstants'
 import { getDefinitionsAction } from '../actions/definitionActions'
 import { curateAction } from '../actions/curationActions'
@@ -325,10 +325,6 @@ class PageDefinitions extends Component {
     this.setState({ ...this.state, sequence: this.state.sequence + 1 })
   }
 
-  noRowsRenderer() {
-    return <div>Select components from the list above ...</div>
-  }
-
   checkSort(sortType) {
     return this.state.activeSort === sortType.value
   }
@@ -346,15 +342,15 @@ class PageDefinitions extends Component {
     return (
       <DropdownButton
         className="list-button"
-        bsStyle={''}
+        bsStyle="default"
         pullRight
         title={title}
         disabled={!this.hasComponents()}
         id={id}
       >
-        {list.map(sortType => {
+        {list.map((sortType, index) => {
           return (
-            <MenuItem onSelect={this.onSort} eventKey={{ type: id, value: sortType.value }}>
+            <MenuItem key={index} onSelect={this.onSort} eventKey={{ type: id, value: sortType.value }}>
               {sortType.label}
               {this.checkSort(sortType) && <i className="fas fa-check pull-right" />}
             </MenuItem>
@@ -368,15 +364,15 @@ class PageDefinitions extends Component {
     return (
       <DropdownButton
         className="list-button"
-        bsStyle={''}
+        bsStyle="default"
         pullRight
         title={title}
         disabled={!this.hasComponents()}
         id={id}
       >
-        {list.map(filterType => {
+        {list.map((filterType, index) => {
           return (
-            <MenuItem onSelect={this.onFilter} eventKey={{ type: id, value: filterType.value }}>
+            <MenuItem key={index} onSelect={this.onFilter} eventKey={{ type: id, value: filterType.value }}>
               {filterType.label}
               {this.checkFilter(filterType, id) && <i className="fas fa-check pull-right" />}
             </MenuItem>
@@ -396,7 +392,7 @@ class PageDefinitions extends Component {
       </div>
     )
   }
-  
+
   collapseComponent(component) {
     this.onChangeComponent(component, { ...component, expanded: false })
   }

--- a/src/components/RehydrationProvider.js
+++ b/src/components/RehydrationProvider.js
@@ -4,18 +4,11 @@
 // Delays loading untill the store is rehydrated
 import React, { Component } from 'react'
 import { persistStore, createTransform } from 'redux-persist'
-import {
-  ROUTE_ROOT,
-  ROUTE_DEFINITIONS,
-  ROUTE_INSPECT,
-  ROUTE_CURATE,
-  ROUTE_HARVEST,
-  ROUTE_ABOUT
-} from '../utils/routingConstants'
+import { ROUTE_ROOT, ROUTE_DEFINITIONS, ROUTE_INSPECT, ROUTE_HARVEST, ROUTE_ABOUT } from '../utils/routingConstants'
 import { configureStore } from '../configureStore'
 import { Provider } from 'react-redux'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
-import { App, PageLanding, PageCurate, PageDefinitions, PageInspect, PageHarvest } from './'
+import { App, PageLanding, PageDefinitions, PageInspect, PageHarvest } from './'
 import { omit } from 'lodash'
 import PageAbout from './PageAbout'
 import withTracker from '../utils/withTracker'

--- a/src/components/RehydrationProvider.js
+++ b/src/components/RehydrationProvider.js
@@ -45,7 +45,6 @@ export default class RehydrationDelayedProvider extends Component {
             <Switch>
               <Route path={ROUTE_DEFINITIONS} component={withTracker(PageDefinitions)} />
               <Route path={ROUTE_INSPECT} component={withTracker(PageInspect)} />
-              {/* <Route path={ROUTE_CURATE} component={withTracker(PageCurate)} /> */}
               <Route path={ROUTE_HARVEST} component={withTracker(PageHarvest)} />
               <Route path={ROUTE_ABOUT} component={withTracker(PageAbout)} />
               <Route path={ROUTE_ROOT} component={withTracker(PageLanding)} />

--- a/src/components/RowEntityList.js
+++ b/src/components/RowEntityList.js
@@ -37,7 +37,6 @@ export default class RowEntityList extends React.Component {
       loadMoreRows,
       listHeight,
       listLength,
-      list,
       rowRenderer,
       noRowsRenderer,
       rowHeight,

--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -34,10 +34,6 @@ const update = (list, item, newValue, comparator = null) => {
   return result
 }
 
-const sort = (list, sortValue) => {
-  return list ? _.sortBy(list, sortValue) : list
-}
-
 const transform = (list, transforms) => {
   let newList = list
   for (let transform in transforms) {
@@ -51,12 +47,6 @@ const transform = (list, transforms) => {
     }
   }
   return newList
-}
-
-function computeTranformed(state, append, list, transformer) {
-  if (!transformer) return state.transformedList
-  const transformed = list.map(entry => transformer(entry))
-  return append ? state.transformedList.concat(transformed) : transformed
 }
 
 export default (name = '', transformer = null, comparator = null) => {

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { ROUTE_CURATE, ROUTE_DEFINITIONS, ROUTE_HARVEST, ROUTE_ABOUT, ROUTE_INSPECT } from '../utils/routingConstants'
+import { ROUTE_DEFINITIONS, ROUTE_HARVEST, ROUTE_ABOUT, ROUTE_INSPECT } from '../utils/routingConstants'
 import {
   UI_NAVIGATION,
   UI_NOTIFICATION_NEW,


### PR DESCRIPTION
With all the refactoring going on there were a number of compile warnings and runtime errors lingering. This fixes most. Some notes:

* the sort and filter button style should not be an empty string. Causes a runtime error and renders oddly in different environments. I set it to default though that is not the look we want either.
* there are still a number of `componentWillReceiveProps is deprecated since React 16.3.0, use UNSAFE_componentWillReceiveProps instead,` We should figure out the right way to do this. We could just use the UNSAFE function but there might be a more generic/modern approach we should use.