### PR TITLE
Disable CRA caching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import './styles/index.css'
-import registerServiceWorker from './registerServiceWorker'
+import { unregister } from './registerServiceWorker'
 import { RehydrationProvider } from './components'
 import ReactGA from 'react-ga'
 ReactGA.initialize(process.env['REACT_APP_GA_TRACKINGID'])
 ReactGA.pageview(window.location.pathname + window.location.search)
 
 ReactDOM.render(<RehydrationProvider />, document.getElementById('root'))
-registerServiceWorker()
+unregister()


### PR DESCRIPTION
Following the [instructions here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#opting-out-of-caching) to disable caching (#99) in the case where the service worker has already been registered.

I'm not able to test this locally, so creating PR so it can be tested. To avoid waiting 24 hours for the cache to be invalidated, you may try the following (in Chrome as an example):

1. Go to https://clearlydefined.io/
2. Open Inspector
3. Right-click the Refresh icon
4. Select **Empty Cache and Hard Reload**

<img width="358" alt="screen shot 2018-07-16 at 11 11 25 am" src="https://user-images.githubusercontent.com/691109/42775419-25c94628-88e9-11e8-81a8-3fe5f178e334.png">

You can follow the above steps if you're in dev mode and leave the existing code as-is. This allows you to see updates immediately and avoid any browser caching.
