### PR TITLE
Use shields.io directly in client

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -68,8 +68,14 @@ export function previewDefinition(token, entity, curation) {
   return post(url(`${DEFINITIONS}/${entity.toPath()}`, { preview: true }), token, curation)
 }
 
-export function getBadgeUrl(entity) {
-  return url(`${BADGES}/${entity.toPath()}`)
+export function getBadgeUrl(definition) {
+  const scoreToUrl = {
+    0: 'https://img.shields.io/badge/ClearlyDefined-0-red.svg',
+    1: 'https://img.shields.io/badge/ClearlyDefined-1-yellow.svg',
+    2: 'https://img.shields.io/badge/ClearlyDefined-2-brightgreen.svg'
+  }
+
+  return scoreToUrl[definition.score];
 }
 
 export function getGitHubSearch(token, path) {

--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -111,7 +111,7 @@ export default class ComponentList extends React.Component {
     const isSourceComponent = this.isSourceComponent(component)
     return (
       <div className="list-activity-area">
-        <img className="list-buttons" src={getBadgeUrl(component)} alt="score" />
+        <img className="list-buttons" src={getBadgeUrl(definition)} alt="score" />
         <ButtonGroup>
           {!isSourceComponent && (
             <Button className="list-hybrid-button" onClick={this.addSourceForComponent.bind(this, component)}>


### PR DESCRIPTION
Avoid using clearly defined API for badges, instead us shield.io directly.

This relies on https://github.com/clearlydefined/service/pull/170

Fixes: https://github.com/clearlydefined/website/issues/138