### PR TITLE
Validation message

### DIFF
--- a/src/actions/curationActions.js
+++ b/src/actions/curationActions.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import React from 'react'
+import { flatten } from 'lodash'
 import { asyncActions } from './'
 import { curate, getCuration } from '../api/clearlyDefined'
 import { uiNotificationNew } from '../actions/ui'
@@ -45,9 +46,12 @@ export function curateAction(token, spec) {
       },
       error => {
         dispatch(actions.error(error))
-        if (error.status === 400)
-          dispatch(uiNotificationNew({ type: 'info', message: 'Incorrect contribution format.', timeout: 5000 }))
-        else dispatch(uiNotificationNew({ type: 'info', message: 'Failed contribution.', timeout: 5000 }))
+        if (error.status === 400) {
+          const errors = flatten(error.body.errors)
+          errors.forEach(e => {
+            dispatch(uiNotificationNew({ type: 'danger', message: `Contribution ERROR: ${e.error.message}` }))
+          })
+        } else dispatch(uiNotificationNew({ type: 'info', message: 'Failed contribution.', timeout: 5000 }))
       }
     )
   }

--- a/src/actions/curationActions.js
+++ b/src/actions/curationActions.js
@@ -45,7 +45,9 @@ export function curateAction(token, spec) {
       },
       error => {
         dispatch(actions.error(error))
-        dispatch(uiNotificationNew({ type: 'info', message: 'Failed contribution.', timeout: 5000 }))
+        if (error.status === 400)
+          dispatch(uiNotificationNew({ type: 'info', message: 'Incorrect contribution format.', timeout: 5000 }))
+        else dispatch(uiNotificationNew({ type: 'info', message: 'Failed contribution.', timeout: 5000 }))
       }
     )
   }

--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -45,7 +45,6 @@ export function getCuration(token, entity) {
   return get(url(`${CURATIONS}/${entity.toPath()}`), token)
 }
 
-
 export function curate(token, spec) {
   return patch(url(`${CURATIONS}`), token, spec)
 }
@@ -123,7 +122,18 @@ function handleResponse(response) {
   // reject if code is out of range 200-299
   if (!response || !response.ok) {
     const err = new Error(response ? response.statusText : 'Error')
-    if (response) err.status = response.status
+    if (response) {
+      err.status = response.status
+      return response
+        .json()
+        .then(body => {
+          err.body = body
+          throw err
+        })
+        .catch(e => {
+          throw err
+        })
+    }
     throw err
   }
   if (response.status === 204) {


### PR DESCRIPTION
Edited the handleResponse() function in clearlyDefined.js. So far when the website gets an error it simply receives an error status. Contribution validation; however, sends over both an error status and an error body. Previously the handleResponse() function was not resolving error bodies. Now the handleResponse() function has the ability to resolve error bodies so the can be used.

Each contribution error appears as a UI message notification now as seen in the picture below. The error messages are based on the new error handling that was introduced in service PR [169](https://github.com/clearlydefined/service/pull/169). This is my first attempt at notifying the user that their contribution is incorrect. Any suggestions will be helpful.

<img width="1622" alt="screen shot 2018-07-18 at 3 59 56 pm" src="https://user-images.githubusercontent.com/23349235/42912591-099c8c54-8aa5-11e8-99f8-4d2f78e05a24.png">


