### PR TITLE
type based props for inline editor

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -27,7 +27,6 @@ function getServiceDefaultUrl() {
 const CURATIONS = 'curations'
 const HARVEST = 'harvest'
 const DEFINITIONS = 'definitions'
-const BADGES = 'badges'
 const ORIGINS_GITHUB = 'origins/github'
 const ORIGINS_NPM = 'origins/npm'
 const ORIGINS_NUGET = 'origins/nuget'

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -227,8 +227,7 @@ export default class DefinitionEntry extends React.Component {
   parseCoordinates(value) {
     if (!value) return null
     const segments = value.split('/')
-    const idx = value.lastIndexOf('/', value.lastIndexOf('/') - 1)
-    const url = value.substring(0, idx)
+    const url = value.replace(/\/commit\/[a-z\d]+$/, '')
     return { type: 'git', provider: 'github', url, revision: segments[6] }
   }
 

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -227,7 +227,9 @@ export default class DefinitionEntry extends React.Component {
   parseCoordinates(value) {
     if (!value) return null
     const segments = value.split('/')
-    return { type: 'git', provider: 'github', url: value, revision: segments[6] }
+    const idx = value.lastIndexOf('/', value.lastIndexOf('/') - 1)
+    const url = value.substring(0, idx)
+    return { type: 'git', provider: 'github', url, revision: segments[6] }
   }
 
   renderLabel(text, editable = false) {

--- a/src/components/InlineEditor.js
+++ b/src/components/InlineEditor.js
@@ -63,12 +63,7 @@ export default class InlineEditor extends React.Component {
         </span>
       )
 
-    return React.cloneElement(this.editors[type](value), {
-      onBlur: this.onChangeEvent,
-      onChange: this.onChange,
-      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
-      ref: this.focus
-    })
+    return React.cloneElement(this.editors[type](value), this.reactProps[type])
   }
 
   render() {
@@ -90,5 +85,24 @@ export default class InlineEditor extends React.Component {
     text: value => <input size="45" type="text" defaultValue={value} />,
     date: value => <input size="45" type="date" defaultValue={value} />,
     license: value => <SpdxPicker value={value} />
+  }
+
+  reactProps = {
+    text: {
+      onBlur: this.onChangeEvent,
+      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
+      ref: this.focus
+    },
+    date: {
+      onBlur: this.onChangeEvent,
+      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
+      ref: this.focus
+    },
+    license: {
+      onBlur: this.onChangeEvent,
+      onChange: this.onChange,
+      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
+      ref: this.focus
+    }
   }
 }

--- a/src/components/InlineEditor.js
+++ b/src/components/InlineEditor.js
@@ -63,7 +63,7 @@ export default class InlineEditor extends React.Component {
         </span>
       )
 
-    return React.cloneElement(this.editors[type](value), this.reactProps[type])
+    return React.cloneElement(this.editors[type](value), this.editorProps[type])
   }
 
   render() {
@@ -87,22 +87,18 @@ export default class InlineEditor extends React.Component {
     license: value => <SpdxPicker value={value} />
   }
 
-  reactProps = {
-    text: {
-      onBlur: this.onChangeEvent,
-      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
-      ref: this.focus
-    },
-    date: {
-      onBlur: this.onChangeEvent,
-      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
-      ref: this.focus
-    },
+  editorDefaults = {
+    onBlur: this.onChangeEvent,
+    onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
+    ref: this.focus
+  }
+
+  editorProps = {
+    text: this.editorDefaults,
+    date: this.editorDefaults,
     license: {
-      onBlur: this.onChangeEvent,
-      onChange: this.onChange,
-      onKeyPress: e => e.key === 'Enter' && this.onChangeEvent(e),
-      ref: this.focus
+      ...this.editorDefaults,
+      onChange: this.onChange
     }
   }
 }


### PR DESCRIPTION
An onChange prop was added as an input to the React.cloneElement. This prop is required for the license picker inline editor; however, causes problems for the date picker inline editor and text inline editor. The onChange prop caused the proxy object itself to trigger and get passed into the onChange function instead of the actual value in the proxy target. Every change should not trigger the onChange function, instead after a user is done editing (onBlur or onKeyPress) the onChange function should be triggered.