### PR TITLE
add all components in single UI render

### DIFF
--- a/src/components/PageDefinitions.js
+++ b/src/components/PageDefinitions.js
@@ -104,15 +104,17 @@ class PageDefinitions extends Component {
           const message = `Invalid component list file: ${listSpec}`
           return dispatch(uiNotificationNew({ type: 'info', message, timeout: 5000 }))
         }
+        const specs = []
         listSpec.coordinates.forEach(component => {
           // TODO figure a way to add these in bulk. One by one will be painful for large lists
           const spec = EntitySpec.validateAndCreate(component)
           if (spec) {
             const path = spec.toPath()
             !definitions.entries[path] && dispatch(getDefinitionsAction(token, [path]))
-            dispatch(uiBrowseUpdateList({ add: spec }))
+            specs.push(spec)
           }
         })
+        dispatch(uiBrowseUpdateList({ addAll: specs }))
       }
       reader.readAsBinaryString(file)
     })

--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -24,6 +24,9 @@ const add = (list, item, comparator = null) => {
   const test = comparator ? element => comparator(element, item) : element => element === item
   return list && !_.find(list, test) ? [...list, item] : list
 }
+const addAll = (list, items) => {
+  return _.uniqWith(_.union(list, items), _.isEqual)
+}
 
 const update = (list, item, newValue, comparator = null) => {
   const test = comparator ? element => comparator(element, item) : element => element === item
@@ -88,6 +91,16 @@ export default (name = '', transformer = null, comparator = null) => {
 
     if (result.add) {
       const newList = add(state.list, result.add, comparator)
+      return {
+        ...state,
+        sequence: ++state.sequence,
+        list: newList,
+        transformedList: transformer ? transformer(newList) : newList
+      }
+    }
+
+    if (result.addAll) {
+      const newList = addAll(state.list, result.addAll)
       return {
         ...state,
         sequence: ++state.sequence,


### PR DESCRIPTION
UI only rendered once when components loaded from file. Adding this along with moving the badge logic to frontend makes the site much more responsive and can quickly process large component lists (ex. package-lock.json files).