### PR TITLE
port addAll changes to new defintions page

### DIFF
--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -25,6 +25,10 @@ const add = (list, item, comparator = null) => {
   return list && !_.find(list, test) ? [...list, item] : list
 }
 
+const addAll = (list, items) => {
+  return _.uniqWith(_.union(list, items), _.isEqual)
+}
+
 const update = (list, item, newValue, comparator = null) => {
   const test = comparator ? element => comparator(element, item) : element => element === item
   const entry = _.findIndex(list, test)
@@ -88,6 +92,16 @@ export default (name = '', transformer = null, comparator = null) => {
 
     if (result.add) {
       const newList = add(state.list, result.add, comparator)
+      return {
+        ...state,
+        sequence: ++state.sequence,
+        list: newList,
+        transformedList: transformer ? transformer(newList) : newList
+      }
+    }
+
+    if (result.addAll) {
+      const newList = addAll(state.list, result.addAll)
       return {
         ...state,
         sequence: ++state.sequence,


### PR DESCRIPTION
@Teju-Manchenella did some changes in #232 but the code has been refactored underneath those changes. This ports the changes to make dropping a list of coordinates happen as a batch rather than one at a time.

@daniellandau you might want to take a look as well.