### PR TITLE
Fix #284 - Full Detail View - Editing Copyrights inside the File Edit is confusing

### DIFF
--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
+
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import isNumber from 'lodash/isNumber'
 import { OverlayTrigger } from 'react-bootstrap'
+
 import PopoverRenderer from './PopoverRenderer'
 
 /**
  * Specific renderer for Copyrights data
- * It show a string of data, and if clicked opens a Popover containing a list of details
+ * It show the first Copyright, and if clicked opens a Popover containing a list of details
  *
  */
 class CopyrightsRenderer extends Component {
@@ -16,16 +19,47 @@ class CopyrightsRenderer extends Component {
   }
 
   state = {
-    hasChanges: false
+    currentItem: null,
+    hasChanges: false,
+    showAddRow: false,
+    values: null
   }
 
-  setHasChanges = hasChanges => {
-    this.setState({ hasChanges })
+  componentDidMount() {
+    this.setState({ values: this.props.item.value })
   }
+
+  onShowAddRow = () => {
+    this.setState({ showAddRow: true, currentItem: null })
+  }
+
+  undoEdit = () => {
+    this.setState({ showAddRow: false, currentItem: null })
+  }
+
+  editRow = index => {
+    this.setState({ showAddRow: false, currentItem: index })
+  }
+
+  deleteRow = index => {
+    this.setState({ values: this.state.values.filter((_, itemIndex) => index !== itemIndex), hasChanges: true })
+  }
+
+  addItem = (value, updatedText) => {
+    const { values, currentItem } = this.state
+    const updatedObject = { value: updatedText || value, isDifferent: true }
+    isNumber(currentItem) ? (values[currentItem] = updatedObject) : values.push(updatedObject)
+    this.setState({ values, showAddRow: false, currentItem: null, hasChanges: true })
+  }
+
+  onSave = () => this.props.onSave(this.state.values.map(item => item.value))
 
   render() {
-    const { item, onSave, readOnly } = this.props
-    const { hasChanges } = this.state
+    const { readOnly } = this.props
+    const { hasChanges, values, showAddRow } = this.state
+
+    if (!values) return null
+
     return (
       <div>
         <OverlayTrigger
@@ -35,19 +69,23 @@ class CopyrightsRenderer extends Component {
           placement="left"
           overlay={
             <PopoverRenderer
-              title={'Copyrights'}
-              values={item.value}
-              editable={!readOnly}
+              addItem={this.addItem}
               canAddItems={!readOnly}
-              onSave={onSave}
-              hasChanges={hasChanges}
-              setHasChanges={this.setHasChanges}
-              editorType={'text'}
+              deleteRow={this.deleteRow}
+              editable={!readOnly}
               editorPlaceHolder={'Copyright'}
+              editorType={'text'}
+              hasChanges={hasChanges}
+              onSave={this.onSave}
+              onShowAddRow={this.onShowAddRow}
+              showAddRow={showAddRow}
+              title={'Copyrights'}
+              undoEdit={this.undoEdit}
+              values={values}
             />
           }
         >
-          <div>{item && item.value && item.value[0] ? item.value[0].value : null}</div>
+          <div>{values && values[0] ? values[0].value : null}</div>
         </OverlayTrigger>
       </div>
     )

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -75,6 +75,7 @@ class CopyrightsRenderer extends Component {
               editable={!readOnly}
               editorPlaceHolder={'Copyright'}
               editorType={'text'}
+              editRow={this.editRow}
               hasChanges={hasChanges}
               onSave={this.onSave}
               onShowAddRow={this.onShowAddRow}

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -47,15 +47,7 @@ class CopyrightsRenderer extends Component {
             />
           }
         >
-          <div className="flexWrap">
-            {item &&
-              item.value &&
-              item.value.map((val, i) => (
-                <span key={i} className={val.isDifferent ? 'facets--isEdited' : ''}>
-                  {val.value}
-                </span>
-              ))}
-          </div>
+          <div>{item && item.value && item.value[0] ? item.value[0].value : null}</div>
         </OverlayTrigger>
       </div>
     )

--- a/src/components/CopyrightsRenderer.js
+++ b/src/components/CopyrightsRenderer.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { OverlayTrigger, ButtonToolbar } from 'react-bootstrap'
+import { OverlayTrigger } from 'react-bootstrap'
 import PopoverRenderer from './PopoverRenderer'
 
 /**
@@ -15,13 +15,22 @@ class CopyrightsRenderer extends Component {
     readOnly: false
   }
 
+  state = {
+    hasChanges: false
+  }
+
+  setHasChanges = hasChanges => {
+    this.setState({ hasChanges })
+  }
+
   render() {
     const { item, onSave, readOnly } = this.props
+    const { hasChanges } = this.state
     return (
       <div>
         <OverlayTrigger
           trigger="click"
-          rootClose
+          rootClose={readOnly || !hasChanges} // hide overlay when the user clicks outside the overlay
           container={document.getElementsByClassName('ReactTable')[0]}
           placement="left"
           overlay={
@@ -31,6 +40,8 @@ class CopyrightsRenderer extends Component {
               editable={!readOnly}
               canAddItems={!readOnly}
               onSave={onSave}
+              hasChanges={hasChanges}
+              setHasChanges={this.setHasChanges}
               editorType={'text'}
               editorPlaceHolder={'Copyright'}
             />

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { Row, Button, Col } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import Tabs from 'antd/lib/tabs'
@@ -267,7 +267,7 @@ class FullDetailComponent extends Component {
           <Col md={1} />
           <Col md={11}>
             <Section name={<span>Described {this.renderScore(item.described)}</span>}>
-              <React.Fragment>
+              <Fragment>
                 {this.renderDescribed(item)}
                 <Row>
                   <Col md={6}>
@@ -281,7 +281,7 @@ class FullDetailComponent extends Component {
                   </Col>
                   <Col md={6}>{this.renderContributions()}</Col>
                 </Row>
-              </React.Fragment>
+              </Fragment>
             </Section>
             <Section name={<span>Licensed {this.renderScore(item.licensed)}</span>}>
               {this.renderLicensed(item)}

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -267,19 +267,21 @@ class FullDetailComponent extends Component {
           <Col md={1} />
           <Col md={11}>
             <Section name={<span>Described {this.renderScore(item.described)}</span>}>
-              {this.renderDescribed(item)}
-              <Row>
-                <Col md={6}>
-                  {this.renderLabel('Facets')}
-                  <FacetsEditor
-                    definition={item}
-                    onChange={onChange}
-                    previewDefinition={previewDefinition}
-                    readOnly={readOnly}
-                  />
-                </Col>
-                <Col md={6}>{this.renderContributions()}</Col>
-              </Row>
+              <React.Fragment>
+                {this.renderDescribed(item)}
+                <Row>
+                  <Col md={6}>
+                    {this.renderLabel('Facets')}
+                    <FacetsEditor
+                      definition={item}
+                      onChange={onChange}
+                      previewDefinition={previewDefinition}
+                      readOnly={readOnly}
+                    />
+                  </Col>
+                  <Col md={6}>{this.renderContributions()}</Col>
+                </Row>
+              </React.Fragment>
             </Section>
             <Section name={<span>Licensed {this.renderScore(item.licensed)}</span>}>
               {this.renderLicensed(item)}

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -24,7 +24,9 @@ class PopoverComponent extends Component {
 
     canAddItems: PropTypes.bool,
     editable: PropTypes.bool,
+    hasChanges: PropTypes.bool.isRequired,
     onSave: PropTypes.func,
+    setHasChanges: PropTypes.func,
     editorType: PropTypes.oneOf(['text', 'date', 'license']).isRequired,
     editorPlaceHolder: PropTypes.string
   }
@@ -35,7 +37,6 @@ class PopoverComponent extends Component {
     this.state = {
       showAddRow: false,
       values: null,
-      hasChanges: false,
       updatedText: ''
     }
 
@@ -56,12 +57,12 @@ class PopoverComponent extends Component {
         <span>{this.props.title}</span>
         <div className="popoverRenderer__title__buttons">
           {this.props.canAddItems && (
-            <Button onClick={() => this.showAddRow()} bsSize="xsmall">
+            <Button onClick={this.showAddRow} bsSize="xsmall">
               <i className="fas fa-plus" />
             </Button>
           )}
-          {this.state.hasChanges && (
-            <Button onClick={() => this.onSave()} bsSize="xsmall">
+          {this.props.hasChanges && (
+            <Button onClick={this.onSave} bsSize="xsmall">
               <i className="fas fa-check" /> Done
             </Button>
           )}
@@ -75,7 +76,7 @@ class PopoverComponent extends Component {
 
     return (
       item && (
-        <div key={`${item.value}_${index}`} className={`popoverRenderer__items`}>
+        <div key={`${item.value}_${index}`} className="popoverRenderer__items">
           <div
             className={`popoverRenderer__items__value ${item.isDifferent && 'popoverRenderer__items__value--isEdited'}`}
           >
@@ -87,7 +88,7 @@ class PopoverComponent extends Component {
                 initialValue={item.value || ''}
                 value={item.value || ''}
                 onChange={this.addItem}
-                validator={true}
+                validator
                 placeholder={editorPlaceHolder}
                 onClick={() => this.editRow(index)}
               />
@@ -139,28 +140,39 @@ class PopoverComponent extends Component {
   }
 
   editRow(index) {
-    this.setState({ showAddRow: false, currentItem: index }, () => console.log(this.state))
+    this.setState({ showAddRow: false, currentItem: index })
   }
 
   deleteRow(index) {
     const { values } = this.state
-    this.setState({ values: values.filter((_, itemIndex) => index !== itemIndex), hasChanges: true })
+    this.setState({ values: values.filter((_, itemIndex) => index !== itemIndex) })
+    this.props.setHasChanges(true)
   }
 
   addItem(value) {
     const { values, currentItem, updatedText } = this.state
     const updatedObject = { value: updatedText || value, isDifferent: true }
     isNumber(currentItem) ? (values[currentItem] = updatedObject) : values.push(updatedObject)
-    this.setState({ values, showAddRow: false, hasChanges: true, currentItem: null })
+    this.setState({ values, showAddRow: false, currentItem: null })
+    this.props.setHasChanges(true)
   }
 
-  onSave() {
+  onSave = () => {
     this.props.onSave(this.state.values.map(item => item.value))
   }
 
   render() {
     const { showAddRow, values } = this.state
-    const { canAdditems, editable, editorType, editorPlaceHolder, onSave, ...popoverProperties } = this.props
+    const {
+      canAddItems,
+      editable,
+      setHasChanges,
+      hasChanges,
+      editorType,
+      editorPlaceHolder,
+      onSave,
+      ...popoverProperties
+    } = this.props
 
     return (
       <Popover

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -21,6 +21,7 @@ class PopoverRenderer extends Component {
     editorPlaceHolder: PropTypes.string,
     editorType: PropTypes.oneOf(['text', 'date', 'license']),
     hasChanges: PropTypes.bool.isRequired,
+    editRow: PropTypes.func,
     onSave: PropTypes.func,
     onShowAddRow: PropTypes.func,
     showAddRow: PropTypes.bool.isRequired,

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -40,7 +40,13 @@ class PopoverRenderer extends Component {
         <span>{title}</span>
         <div className="popoverRenderer__title__buttons">
           {canAddItems && (
-            <Button onClick={onShowAddRow} bsSize="xsmall">
+            <Button
+              onClick={() => {
+                onShowAddRow()
+                this.setState({ updatedText: '' })
+              }}
+              bsSize="xsmall"
+            >
               <i className="fas fa-plus" />
             </Button>
           )}
@@ -104,7 +110,10 @@ class PopoverRenderer extends Component {
             placeholder="Enter text"
             value={updatedText}
             onChange={event => this.setState({ updatedText: event.target.value })}
-            onBlur={this.props.undoEdit}
+            onBlur={() => {
+              this.props.undoEdit()
+              this.setState({ updatedText: '' })
+            }}
             className="popoverRenderer__items__formControl"
           />
         </FormGroup>

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -100,6 +100,7 @@ class PopoverRenderer extends Component {
         <FormGroup className="popoverRenderer__items__formGroup">
           <FormControl
             type="text"
+            autoFocus
             placeholder="Enter text"
             value={updatedText}
             onChange={event => this.setState({ updatedText: event.target.value })}
@@ -115,21 +116,14 @@ class PopoverRenderer extends Component {
   }
 
   render() {
-    const {
-      canAddItems,
-      editable,
-      setHasChanges,
-      hasChanges,
-      editorType,
-      editorPlaceHolder,
-      onSave,
-      ...popoverProperties
-    } = this.props
+    const { values, showAddRow, placement, positionLeft, positionTop } = this.props
 
     return (
       <Popover
         id="popover-positioned-left"
-        {...popoverProperties}
+        placement={placement}
+        positionLeft={positionLeft}
+        positionTop={positionTop}
         title={this.renderPopoverTitle()}
         bsStyle={{ width: '500px' }}
       >

--- a/src/components/PopoverRenderer.js
+++ b/src/components/PopoverRenderer.js
@@ -11,7 +11,7 @@ import InlineEditor from './InlineEditor'
  * Data could be string or array of strings
  *
  */
-class PopoverComponent extends Component {
+class PopoverRenderer extends Component {
   static propTypes = {
     /**
      * title to show on the Popover
@@ -192,4 +192,4 @@ class PopoverComponent extends Component {
   }
 }
 
-export default PopoverComponent
+export default PopoverRenderer


### PR DESCRIPTION
This PR has 3 changes:

1. Implementation of the following solution for #284 :
> Keep the Popover open when editing, so the user MUST click on "Done". Making sure to allow the close the Popover when there are no changes (read-only)

In order to do this, the state of the Copyright values and the functions changing that same state had to be moved from the `PopoverRenderer` to the `CopyRightsRenderer`.

Otherwise when a Copyright item is deleted the PopoverRenderer component will re-render, losing that change.

2. Reverting https://github.com/clearlydefined/website/commit/a77b559a4976a970a043f2e3bd9f90505339c353 (FileList: display all copyrights and highlight the different ones)

If there many Copyrights for a file, this list could be very long and this change was not part of #278 

3. Small UX improvement

Automatically focus the input field when adding a new Copyright, so you can type as soon as you press the `+` button