### PR TITLE
Issue #329 - "Pencil" icon for selecting declared license redirects you to a blank page when clicked

### DIFF
--- a/src/utils/contribution.js
+++ b/src/utils/contribution.js
@@ -239,7 +239,7 @@ export default class Contribution {
     let discoveredUnknown = 0
     let parties = []
     let expressions = []
-    let declared = []
+    let declared = null
 
     facets.forEach(name => {
       const facet = get(definition, `licensed.facets.${name}`)


### PR DESCRIPTION
Fixes #329 