### PR TITLE
Gist Support for import/export lists of definitions

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -161,6 +161,14 @@ export function getNugetRevisions(token, path) {
   return get(url(`${ORIGINS_NUGET}/${path}/revisions`), token)
 }
 
+export function createGist(token, file) {
+  return post('https://api.github.com/gists', token, file)
+}
+
+export function getGist(file) {
+  return get(`https://api.github.com/gists/${file}`)
+}
+
 // ========================== utilities ====================
 
 export function url(path, query) {

--- a/src/utils/__tests__/providers.test.js
+++ b/src/utils/__tests__/providers.test.js
@@ -1,0 +1,107 @@
+import { Provider } from '../providers'
+
+describe('Provider', () => {
+  it('dropping a non-URL, it should return false', async () => {
+    const provider = new Provider()
+    const result = await provider.setUrl('dfgsfgdfg')
+    expect(result).toEqual(false)
+  })
+  it('returns a npm path without version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://www.npmjs.com/package/deep-diff')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'npmjs.com need a version to be imported' })
+  })
+  it('returns a npm path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://www.npmjs.com/package/async/v/2.6.0')
+    const result = await provider.getContent()
+    expect(result).toEqual('npm/npmjs/-/async/2.6.0')
+  })
+  it('returns a github path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://github.com/github/fetch/releases/tag/v3.0.0')
+    const result = await provider.getContent()
+    expect(result).toEqual('git/github/github/fetch/v3.0.0')
+  })
+  it('returns a github path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl(
+      'https://github.com/github/fetch/commit/d4ed806fdcbdeaef707d27f6c88943f0336a647d'
+    )
+    const result = await provider.getContent()
+    expect(result).toEqual('git/github/github/fetch/d4ed806fdcbdeaef707d27f6c88943f0336a647d')
+  })
+  it('posting a github path without version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://github.com/github/fetch')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'github.com need a version to be imported' })
+  })
+  it('returns a maven path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://mvnrepository.com/artifact/cc.mallet/mallet/2.0.8')
+    const result = await provider.getContent()
+    expect(result).toEqual('maven/mavencentral/cc.mallet/mallet/2.0.8')
+  })
+  it('posting a maven path without a version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://mvnrepository.com/artifact/cc.mallet/mallet')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'mvnrepository.com need a version to be imported' })
+  })
+  it('returns a pypi path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://pypi.org/project/pyaml/17.8.0/')
+    const result = await provider.getContent()
+    expect(result).toEqual('pypi/pypi/-/pyaml/17.8.0')
+  })
+  it('posting a pypi path without a version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://pypi.org/project/pyaml/')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'pypi.org need a version to be imported' })
+  })
+  it('returns a nuget path with a version', async () => {
+    const provider = new Provider()
+    provider.setUrl('https://nuget.org/packages/NuGet.VisualStudio/2.8.2')
+    const result = await provider.getContent()
+    expect(result).toEqual('nuget/nuget/-/NuGet.VisualStudio/2.8.2')
+  })
+  it('posting a nuget path without a version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://www.nuget.org/packages/NuGet.VisualStudio/')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'nuget.org need a version to be imported' })
+  })
+  it('returns a rubygem path with a version', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://rubygems.org/gems/tzinfo/versions/1.2.5')
+    const result = await provider.getContent()
+    expect(result).toEqual('gem/rubygems/-/tzinfo/1.2.5')
+  })
+  it('posting a rubygem path without a version, returns an error message', async () => {
+    const provider = new Provider()
+    const providerResult = await provider.setUrl('https://rubygems.org/gems/tzinfo')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'rubygems.org need a version to be imported' })
+  })
+  it('posting a gist url without id, returns an error message', async () => {
+    const provider = new Provider()
+    // TODO: find a strategy to test gist url for the user during the CI process, currently is used a specific gist URL
+    const providerResult = await provider.setUrl('https://gist.github.com/storrisi')
+    const result = await provider.getContent()
+    expect(result).toEqual({ errors: 'gist.github.com need a valid ID to be imported' })
+  })
+  it('returns a gist content', async () => {
+    const provider = new Provider()
+    // TODO: find a strategy to test gist url for the user during the CI process, currently is used a specific gist URL
+    const providerResult = await provider.setUrl('https://gist.github.com/storrisi/1cf5f1dba25e670d48b1ff1fd0b76528')
+    const result = await provider.getContent()
+    expect(result).toEqual({
+      coordinates: [{ name: 'async', provider: 'npmjs', revision: '2.6.0', type: 'npm' }],
+      filter: {},
+      sortBy: null
+    })
+  })
+})

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -8,7 +8,7 @@ export default class Auth {
    * Open the service's auth page and execute a callback with the returned data from the server
    */
   static doLogin(callback) {
-    console.log('login')
+    console.log('login', url('auth/github'))
     window.open(url('auth/github'))
     const tokenListener = e => {
       if (e.data.type === 'github-token') {

--- a/src/utils/providers.js
+++ b/src/utils/providers.js
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+import map from 'lodash/map'
+import { createGist, getGist } from '../api/clearlyDefined'
+
+// Provider class is intended to exposing methods that could be used on each single specific provider
+export class Provider {
+  constructor() {
+    // List of all accepted providers
+    this.providers = [
+      new NpmProvider(),
+      new GitHubProvider(),
+      new MavenProvider(),
+      new PyPiProvider(),
+      new NugetProvider(),
+      new RubyGemProvider(),
+      new GistProvider()
+    ]
+  }
+
+  // Accept a URL, and passes to each single provider the properties to analyze it
+  async setUrl(url) {
+    try {
+      const urlObject = new URL(url)
+      this.pathname = urlObject.pathname.startsWith('/') ? urlObject.pathname.slice(1) : urlObject.pathname
+      this.hostname = urlObject.hostname.replace('www.', '')
+      this.urlPath = this.pathname.split('/')
+      this.providers.map(provider => provider.setUrl(this.urlPath, this.hostname))
+    } catch (errors) {
+      return false
+    }
+  }
+
+  // Given a URL, returns the content of the specific provider
+  async getContent() {
+    try {
+      const content = await this.providers.reduce(async (result, provider) => {
+        const isValid = await this.isValid(this.hostname, provider.hostnames)
+        if (!isValid) return result
+        const returnedContent = await provider.get()
+        return returnedContent
+      }, false)
+      return content
+    } catch (errors) {
+      console.log(errors)
+      return false
+    }
+  }
+
+  isValid(hostname, hostnames) {
+    return this.checkValidHostname(hostnames, hostname)
+  }
+
+  checkValidHostname(providerHostnames, hostname) {
+    return providerHostnames.indexOf(hostname) >= 0 && true
+  }
+}
+
+// Implements all the generic methods for the Providers
+export class GenericProvider {
+  setUrl(urlPath, hostname) {
+    this.hostname = hostname
+    this.urlPath = urlPath
+  }
+
+  providerErrorsFallback(message) {
+    return { errors: message }
+  }
+}
+
+/**
+ * Specific provider class that extends the basic functionality of the GenericProvider
+ * Each provider could implement specific values and methods, used by the Provider class
+ */
+export class NpmProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['npmjs.org', 'npmjs.com'] // Hostnames accepted for this provider
+    this.path = 'npm/npmjs' // Basic path structure for this provider
+  }
+
+  // Function to parse the URL structure and convert it to specific data of the provider
+  get() {
+    let nameSpace, name, revision
+    if (this.urlPath.length === 5) {
+      ;[, nameSpace, name, , revision] = this.urlPath
+    } else {
+      nameSpace = '-'
+      ;[, name, , revision] = this.urlPath
+    }
+    return revision
+      ? `${this.path}/${nameSpace}/${name}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+
+export class GitHubProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['github.com']
+    this.path = 'git/github'
+  }
+
+  get() {
+    let packageName, name, revision
+    if (this.urlPath.length === 5) {
+      ;[packageName, name, , , revision] = this.urlPath
+    } else {
+      ;[packageName, name, , revision] = this.urlPath
+    }
+    return revision
+      ? `${this.path}/${packageName}/${name}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+
+export class MavenProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['mvnrepository.com']
+    this.path = 'maven/mavencentral'
+  }
+
+  get() {
+    const [, name, version, revision] = this.urlPath
+    return revision
+      ? `${this.path}/${name}/${version}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+
+export class PyPiProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['pypi.org']
+    this.path = 'pypi/pypi/-'
+  }
+
+  get() {
+    const [, name, revision] = this.urlPath
+    return revision
+      ? `${this.path}/${name}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+
+export class NugetProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['nuget.org']
+    this.path = 'nuget/nuget/-'
+  }
+
+  get() {
+    const [, name, revision] = this.urlPath
+    return revision
+      ? `${this.path}/${name}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+export class RubyGemProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['rubygems.org']
+    this.path = 'gem/rubygems/-'
+  }
+
+  get() {
+    const [, name, , revision] = this.urlPath
+    return revision
+      ? `${this.path}/${name}/${revision}`
+      : this.providerErrorsFallback(`${this.hostname} need a version to be imported`)
+  }
+}
+
+export class GistProvider extends GenericProvider {
+  constructor(urlPath, hostname) {
+    super(urlPath, hostname)
+    this.hostnames = ['gist.github.com']
+  }
+
+  static async save(token, fileName, fileContent) {
+    try {
+      const res = await createGist(token, {
+        files: {
+          [fileName]: {
+            content: fileContent
+          }
+        }
+      })
+      return res.html_url
+    } catch (errors) {
+      console.log(errors)
+    }
+  }
+
+  // Gist provider needs to retrieve data from the API
+  get() {
+    const [user, gistId] = this.urlPath
+    if (!gistId) return this.providerErrorsFallback(`${this.hostname} need a valid ID to be imported`)
+    return getGist(gistId)
+      .then(res => {
+        return map(res.files, file => JSON.parse(file.content))[0]
+      })
+      .catch(errors => console.log(errors))
+  }
+}


### PR DESCRIPTION
In order to allow the user to export the list of definitions into a gist file, it need a proper scope to the github authentication, which has already been addressed here: https://github.com/clearlydefined/service/issues/272

In this PR, has been implemented a solution to manage Providers objects and methods.

Fixes #168 

