### PR TITLE
encasulate version selection origin handling

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -3,6 +3,7 @@
 // DON'T COMMIT THIS FILE
 import 'whatwg-fetch'
 import { toPairs } from 'lodash'
+import _ from 'lodash'
 import EntitySpec from '../utils/entitySpec'
 
 export const apiHome = process.env.REACT_APP_SERVER
@@ -17,12 +18,12 @@ export const ORIGINS_MAVEN = 'origins/maven'
 export const ORIGINS_PYPI = 'origins/pypi'
 export const ORIGINS_RUBYGEMS = 'origins/rubygems'
 export const ORIGINS = {
-  git: ORIGINS_GITHUB,
-  npm: ORIGINS_NPM,
-  nuget: ORIGINS_NUGET,
-  maven: ORIGINS_MAVEN,
-  pypi: ORIGINS_PYPI,
-  gem: ORIGINS_RUBYGEMS
+  github: { git: ORIGINS_GITHUB },
+  npmjs: { npm: ORIGINS_NPM },
+  nuget: { nuget: ORIGINS_NUGET },
+  mavencentral: { maven: ORIGINS_MAVEN, sourcearchive: ORIGINS_MAVEN },
+  pypi: { pypi: ORIGINS_PYPI },
+  rubygems: { gem: ORIGINS_RUBYGEMS }
 }
 
 export function getHarvestResults(token, entity) {
@@ -169,8 +170,9 @@ export function getNugetRevisions(token, path) {
   return get(url(`${ORIGINS_NUGET}/${path}/revisions`), token)
 }
 
-export function getRevisions(token, path, origin) {
-  return get(url(`${ORIGINS[origin]}/${path}/revisions`), token)
+export function getRevisions(token, path, type, provider) {
+  const origin = _.get(ORIGINS, `${provider}.${type}`)
+  return get(url(`${origin}/${path}/revisions`), token)
 }
 
 // ========================== utilities ====================

--- a/src/components/Navigation/Ui/VersionSelector.js
+++ b/src/components/Navigation/Ui/VersionSelector.js
@@ -24,16 +24,12 @@ class VersionSelector extends Component {
   async componentDidMount() {
     const { component, token, multiple } = this.props
     if (!component) return
+    const fullname = component.namespace ? `${component.namespace}/${component.name}` : component.name
     try {
       const label = multiple
-        ? `Pick one or move versions of ${EntitySpec.getEntityName(component)} to add to the definitions list`
-        : `Pick a different version of ${EntitySpec.getEntityName(component)}`
-
-      const options = await getRevisions(
-        token,
-        EntitySpec.getEntityName(component),
-        EntitySpec.getEntityOrigin(component)
-      )
+        ? `Pick one or move versions of ${fullname} to add to the definitions list`
+        : `Pick a different version of ${fullname}`
+      const options = await getRevisions(token, fullname, component.type, component.provider)
       this.setState({ options, label })
     } catch (error) {
       console.log(error)

--- a/src/utils/entitySpec.js
+++ b/src/utils/entitySpec.js
@@ -1,5 +1,3 @@
-import { ORIGINS } from '../api/clearlyDefined'
-
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
@@ -181,12 +179,5 @@ export default class EntitySpec {
 
   toString() {
     return this.toPath()
-  }
-
-  static getEntityName(component) {
-    return component.namespace ? `${component.namespace}/${component.name}` : component.name
-  }
-  static getEntityOrigin(component) {
-    return component.type
   }
 }


### PR DESCRIPTION
@storrisi this is what I meant about the management of origins and entity specs. The UI is trafficking in a plain object, EntitySpec should not know anything about origin URLs and the origin mapping, in the fullness of time, is a combo of type and provider (e.g., we will want to get `releases` from github and git things from gitlab, ...)