### PR TITLE
first cut at fixing erroneous expansion toggling

### DIFF
--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -53,8 +53,13 @@ export default class ComponentButtons extends Component {
     action && sourceEntity && action(sourceEntity, component)
   }
 
+  showVersionSelectorPopup(component, multiple, event) {
+    event.domEvent.stopPropagation()
+    this.props.showVersionSelectorPopup(component, multiple)
+  }
+
   render() {
-    const { definition, currentComponent, readOnly, hasChange, showVersionSelectorPopup } = this.props
+    const { definition, currentComponent, readOnly, hasChange } = this.props
     const component = EntitySpec.fromCoordinates(currentComponent)
     const isSourceComponent = this.isSourceComponent(component)
     const scores = Definition.computeScores(definition)
@@ -106,16 +111,16 @@ export default class ComponentButtons extends Component {
               <Dropdown
                 overlay={
                   <Menu>
-                    <Menu.Item onClick={() => showVersionSelectorPopup(currentComponent, false)}>
-                      Switch Version
+                    <Menu.Item onClick={this.showVersionSelectorPopup.bind(this, currentComponent, false)}>
+                      Switch version
                     </Menu.Item>
-                    <Menu.Item onClick={() => showVersionSelectorPopup(currentComponent, true)}>
-                      Add more Versions
+                    <Menu.Item onClick={this.showVersionSelectorPopup.bind(this, currentComponent, true)}>
+                      Add more versions
                     </Menu.Item>
                   </Menu>
                 }
               >
-                <Button className="list-fa-button">
+                <Button className="list-fa-button" onClick={event => event.stopPropagation()}>
                   <i className="fas fa-exchange-alt" /> <Icon type="down" />
                 </Button>
               </Dropdown>


### PR DESCRIPTION
In the Definitions page if you have an entry and click on the button to drop down the Select/Add a version menu, the row for that entry expands or collapses. Similarly, if you hover over the drop down and then select a menu entry.

This fix adds `stopPropagation()` to the handler for the menu click and the dropdown expand handler. The former seems to do the right thing. The latter feels wrong and does not actually work correctly. with this change clicking on the button does not expand/collapse the menu like it should. Without the change, the menu behaves correctly but the row also expands collapses.

The `DropDown` component really should be consuming this itself. Perhaps there is a setting on the Antd dropdown?

BTW, why are we using Antd for things like this. The default should be Bootstrap. For the most part the site is Bootstrap. Where there is something it does not have, we can use Antd. It feels odd to mixing these frameworks on the simple things like buttons and dropdowns.