### PR TITLE
Add support for saving/loading gist-based lists

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -57,6 +57,19 @@ export function uiRedirect(to) {
 }
 
 let nextNotificationId = 0
+
+export function uiInfo(dispatch, message, timeout = 5000) {
+  dispatch(uiNotificationNew({ type: 'info', message, timeout }))
+}
+
+export function uiWarning(dispatch, message, timeout = 5000) {
+  dispatch(uiNotificationNew({ type: 'warning', message, timeout }))
+}
+
+export function uiDanger(dispatch, message, timeout = 5000) {
+  dispatch(uiNotificationNew({ type: 'danger', message, timeout }))
+}
+
 export function uiNotificationNew(message) {
   return { type: UI_NOTIFICATION_NEW, message: { ...message, id: nextNotificationId++ } }
 }

--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-import 'whatwg-fetch'
+import { get, getList, patch, post } from './generic'
 import { toPairs } from 'lodash'
 import _ from 'lodash'
 import EntitySpec from '../utils/entitySpec'
 
-export const apiHome = process.env.REACT_APP_SERVER
+const apiHome = process.env.REACT_APP_SERVER
 
 export const CURATIONS = 'curations'
 export const HARVEST = 'harvest'
@@ -190,89 +190,4 @@ export function url(path, query) {
     .map(p => p.map(encodeURIComponent).join('='))
     .join('&')
   return queryString ? `${path}?${queryString}` : path
-}
-
-function getHeaders(token) {
-  const result = {
-    'Content-Type': 'application/json; charset=utf-8'
-  }
-  if (token) result.Authorization = 'Bearer ' + token
-  return result
-}
-
-function handleResponse(response) {
-  // reject if code is out of range 200-299
-  if (!response || !response.ok) {
-    const err = new Error(response ? response.statusText : 'Error')
-    if (response) {
-      err.status = response.status
-      return response
-        .json()
-        .then(body => {
-          err.body = body
-          throw err
-        })
-        .catch(() => {
-          throw err
-        })
-    }
-    throw err
-  }
-  if (response.status === 204) {
-    // handle NO DATA
-    const err = new Error(response ? response.statusText : 'No data')
-    err.status = 204
-    throw err
-  }
-  return response.json()
-}
-
-async function handleListResponse(response) {
-  const list = await handleResponse(response)
-  return { list, headers: response.headers }
-}
-
-// function put(url, token, payload) {
-//   return fetch(url, {
-//     headers: getHeaders(token),
-//     method: 'PUT',
-//     body: JSON.stringify(payload)
-//   })
-//     .then(handleResponse)
-// }
-
-function post(url, token, payload) {
-  return fetch(url, {
-    headers: getHeaders(token),
-    method: 'POST',
-    body: JSON.stringify(payload)
-  }).then(handleResponse)
-}
-
-function patch(url, token, payload) {
-  return fetch(url, {
-    headers: getHeaders(token),
-    method: 'PATCH',
-    body: JSON.stringify(payload)
-  }).then(handleResponse)
-}
-
-// function del(url, token) {
-//   return fetch(url, {
-//     headers: getHeaders(token),
-//     method: 'DELETE'
-//   })
-//     .then(handleResponse)
-// }
-
-function get(url, token) {
-  return fetch(url, {
-    headers: getHeaders(token)
-  }).then(handleResponse)
-}
-
-function getList(url, token) {
-  return fetch(url, {
-    headers: getHeaders(token)
-  }).then(handleListResponse)
 }

--- a/src/api/generic.js
+++ b/src/api/generic.js
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import 'whatwg-fetch'
+
+function getHeaders(token) {
+  const result = {
+    'Content-Type': 'application/json; charset=utf-8'
+  }
+  if (token) result.Authorization = 'Bearer ' + token
+  return result
+}
+
+function handleResponse(response) {
+  // reject if code is out of range 200-299
+  if (!response || !response.ok) {
+    const err = new Error(response ? response.statusText : 'Error')
+    if (response) {
+      err.status = response.status
+      return response
+        .json()
+        .then(body => {
+          err.body = body
+          throw err
+        })
+        .catch(() => {
+          throw err
+        })
+    }
+    throw err
+  }
+  if (response.status === 204) {
+    // handle NO DATA
+    const err = new Error(response ? response.statusText : 'No data')
+    err.status = 204
+    throw err
+  }
+  return response.json()
+}
+
+async function handleListResponse(response) {
+  const list = await handleResponse(response)
+  return { list, headers: response.headers }
+}
+
+// export function put(url, token, payload) {
+//   return fetch(url, {
+//     headers: getHeaders(token),
+//     method: 'PUT',
+//     body: JSON.stringify(payload)
+//   })
+//     .then(handleResponse)
+// }
+
+export function post(url, token, payload) {
+  return fetch(url, {
+    headers: getHeaders(token),
+    method: 'POST',
+    body: JSON.stringify(payload)
+  }).then(handleResponse)
+}
+
+export function patch(url, token, payload) {
+  return fetch(url, {
+    headers: getHeaders(token),
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  }).then(handleResponse)
+}
+
+// export function del(url, token) {
+//   return fetch(url, {
+//     headers: getHeaders(token),
+//     method: 'DELETE'
+//   })
+//     .then(handleResponse)
+// }
+
+export function get(url, token) {
+  return fetch(url, {
+    headers: getHeaders(token)
+  }).then(handleResponse)
+}
+
+export function getList(url, token) {
+  return fetch(url, {
+    headers: getHeaders(token)
+  }).then(handleListResponse)
+}

--- a/src/api/github.js
+++ b/src/api/github.js
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import { get, post } from './generic'
+
+export async function saveGist(token, name, fileContent) {
+  if (typeof fileContent !== 'string') fileContent = JSON.stringify(fileContent)
+  const result = await post('https://api.github.com/gists', token, { files: { [name]: { content: fileContent } } })
+  return result.html_url
+}
+
+export async function getGist(id) {
+  const gist = await get(`https://api.github.com/gists/${id}`)
+  for (let file in gist.files) {
+    gist.files[file] = JSON.parse(gist.files[file].content)
+  }
+  console.log(gist.files)
+  return gist.files
+}


### PR DESCRIPTION
Building on #356, this PR integrates gist support into the new provider and api approach. #356 is obsoleted by this (and a previously merged PR).

There is an open question:
* How to get a token that will allow the site to create a Gist in the user's account. The normal token we get does not have permissions AFAICT. Not sure how it worked in #356 as we use the same technique/token here and end up with a 404 on POST to create the Gist.

Probably should not merge until we sort this out.