### PR TITLE
adapt score rendering to new score structure

### DIFF
--- a/src/actions/__tests__/definitions.test.js
+++ b/src/actions/__tests__/definitions.test.js
@@ -22,12 +22,12 @@ const mockedDefinition = {
       projectWebsite: 'https://caolan.github.io/async/',
       issueTracker: 'https://github.com/caolan/async/issues',
       tools: ['scancode/2.2.1', 'clearlydefined/1', 'curation/63b2dde4188849a660de4ebe44f301f34c2e7886'],
-      toolScore: 2,
-      score: 2
+      toolScore: { total: 2 },
+      score: { total: 2 }
     },
     licensed: {
       declared: 'Apache-2.0',
-      toolScore: 2,
+      toolScore: { total: 2 },
       facets: {
         core: {
           attribution: { unknown: 2, parties: ['Copyright (c) 2010-2017 Caolan McMahon'] },
@@ -35,7 +35,7 @@ const mockedDefinition = {
           files: 3
         }
       },
-      score: 2
+      score: { total: 2 }
     },
     files: [
       { path: 'package/bower.json' },

--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -116,7 +116,9 @@ export function previewDefinition(token, entity, curation) {
 }
 
 export function getBadgeUrl(score1, score2) {
-  const topScore = 2
+  score1 = score1 || 0
+  score2 = score2 || 0
+  const topScore = 100
   const colors = ['red', 'yellow', 'brightgreen']
   const percentScore = (score1 + score2) / (2 * topScore)
   const bucketSize = 1 / (colors.length - 1)

--- a/src/components/Navigation/Ui/TitleWithScore.js
+++ b/src/components/Navigation/Ui/TitleWithScore.js
@@ -3,20 +3,30 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { getBadgeUrl } from '../../../api/clearlyDefined'
+import get from 'lodash/get'
 
 class TitleWithScore extends Component {
   static propTypes = {
     title: PropTypes.string,
     domain: PropTypes.object
   }
+
   constructor(props) {
     super(props)
     this.renderScore = this.renderScore.bind(this)
   }
+
   renderScore(domain) {
     if (!domain) return null
-    return <img className="list-buttons" src={getBadgeUrl(domain.toolScore, domain.score)} alt="score" />
+    return (
+      <img
+        className="list-buttons"
+        src={getBadgeUrl(get(domain, 'toolScore.total'), get(domain, 'score.total'))}
+        alt="score"
+      />
+    )
   }
+
   render() {
     const { title, domain } = this.props
     return (

--- a/src/components/Navigation/Ui/__tests__/ComponentButtons.test.js
+++ b/src/components/Navigation/Ui/__tests__/ComponentButtons.test.js
@@ -18,12 +18,12 @@ const mockedDefinition = {
     projectWebsite: 'https://caolan.github.io/async/',
     issueTracker: 'https://github.com/caolan/async/issues',
     tools: ['scancode/2.2.1', 'clearlydefined/1', 'curation/63b2dde4188849a660de4ebe44f301f34c2e7886'],
-    toolScore: 2,
-    score: 2
+    toolScore: { total: 2 },
+    score: { total: 2 }
   },
   licensed: {
     declared: 'Apache-2.0',
-    toolScore: 2,
+    toolScore: { total: 2 },
     facets: {
       core: {
         attribution: { unknown: 2, parties: ['Copyright (c) 2010-2017 Caolan McMahon'] },
@@ -31,7 +31,7 @@ const mockedDefinition = {
         files: 3
       }
     },
-    score: 2
+    score: { total: 2 }
   },
   files: [
     { path: 'package/bower.json' },

--- a/src/reducers/__tests__/definition.test.js
+++ b/src/reducers/__tests__/definition.test.js
@@ -15,12 +15,12 @@ const mockedDefinition = {
       projectWebsite: 'https://caolan.github.io/async/',
       issueTracker: 'https://github.com/caolan/async/issues',
       tools: ['scancode/2.2.1', 'clearlydefined/1', 'curation/63b2dde4188849a660de4ebe44f301f34c2e7886'],
-      toolScore: 2,
-      score: 2
+      toolScore: { total: 2 },
+      score: { total: 2 }
     },
     licensed: {
       declared: 'Apache-2.0',
-      toolScore: 2,
+      toolScore: { total: 2 },
       facets: {
         core: {
           attribution: {
@@ -34,7 +34,7 @@ const mockedDefinition = {
           files: 3
         }
       },
-      score: 2
+      score: { total: 2 }
     },
     files: [
       {

--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -28,8 +28,12 @@ export default class Definition {
 
   static computeScores(definition) {
     if (!get(definition, 'described')) return null
-    const tool = Math.ceil((get(definition, 'described.toolScore', 0) + get(definition, 'licensed.toolScore', 0)) / 2)
-    const effective = Math.ceil((get(definition, 'described.score', 0) + get(definition, 'licensed.score', 0)) / 2)
+    const tool = Math.ceil(
+      (get(definition, 'described.toolScore.total', 0) + get(definition, 'licensed.toolScore.total', 0)) / 2
+    )
+    const effective = Math.ceil(
+      (get(definition, 'described.score.total', 0) + get(definition, 'licensed.score.total', 0)) / 2
+    )
     return { tool, effective }
   }
 


### PR DESCRIPTION
PR https://github.com/clearlydefined/service/pull/291 implements a new scoring algorithm and data structure. This PR updated the website to use the new structure. Basically the returned scores are now a structure with a `total` property (and others). need to get the total rather than just expect the score to be a number.

**Must be merged with https://github.com/clearlydefined/service/pull/291**