### PR TITLE
Fix typo on browse page

### DIFF
--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -33,7 +33,7 @@ class PageBrowse extends SystemManagedList {
 
   noRowsRenderer() {
     return (
-      <div className="list-noRows">Select a Provider to retrieve a list of definition that needs to be curated</div>
+      <div className="list-noRows">Select a Provider to retrieve a list of definitions that need to be curated</div>
     )
   }
 


### PR DESCRIPTION
Change "list of definition that needs" to "list of definitions that need"