### PR TITLE
Fix for change of schema definition

### DIFF
--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -91,12 +91,14 @@ export default class Definition {
     if (!get(definition, '_meta')) return
     const { pending, merged } = get(definition, '_meta')
     return union(
-      pending.map(item => {
-        return { ...item, status: 'pending' }
-      }),
-      merged.map(item => {
-        return { ...item, status: 'merged' }
-      })
+      pending &&
+        pending.map(item => {
+          return { ...item, status: 'pending' }
+        }),
+      merged &&
+        merged.map(item => {
+          return { ...item, status: 'merged' }
+        })
     )
   }
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/clearlydefined/service/pull/323 related to the `_meta` property of the definition schema