### PR TITLE
Issue #385 - Add score detail (#58)

### DIFF
--- a/src/components/InlineEditor.js
+++ b/src/components/InlineEditor.js
@@ -4,7 +4,6 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
-import Tooltip from 'antd/lib/tooltip'
 import { SpdxPicker } from './'
 import withSuggestions from '../utils/withSuggestions'
 class InlineEditor extends React.Component {

--- a/src/components/Navigation/Sections/HeaderSection.js
+++ b/src/components/Navigation/Sections/HeaderSection.js
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types'
 import { Row, Button, Col } from 'react-bootstrap'
 import isEmpty from 'lodash/isEmpty'
 import { Tag } from 'antd'
-import { getBadgeUrl } from '../../../api/clearlyDefined'
 import Definition from '../../../utils/definition'
 import ButtonWithTooltip from '../Ui/ButtonWithTooltip'
+import ScoreRenderer from '../Ui/ScoreRenderer'
 
 export default class HeaderSection extends Component {
   static propTypes = {
@@ -37,7 +37,7 @@ export default class HeaderSection extends Component {
               <div className="header-data">
                 {scores && (
                   <span className="score-header">
-                    <img className="list-buttons" src={getBadgeUrl(scores.tool, scores.effective)} alt="score" />
+                    <ScoreRenderer scores={scores} definition={item} />
                   </span>
                 )}
                 {isCurated && <Tag color="green">Curated</Tag>}

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -7,9 +7,9 @@ import { Menu, Dropdown, Icon } from 'antd'
 import { CopyUrlButton } from '../../'
 import EntitySpec from '../../../utils/entitySpec'
 import Definition from '../../../utils/definition'
-import { getBadgeUrl } from '../../../api/clearlyDefined'
 import { ROUTE_DEFINITIONS } from '../../../utils/routingConstants'
 import ButtonWithTooltip from './ButtonWithTooltip'
+import ScoreRenderer from './ScoreRenderer'
 
 export default class ComponentButtons extends Component {
   static propTypes = {
@@ -69,7 +69,7 @@ export default class ComponentButtons extends Component {
     const hasPendingCurations = Definition.hasPendingCurations(definition)
     return (
       <div className="list-activity-area">
-        {scores && <img className="list-buttons" src={getBadgeUrl(scores.tool, scores.effective)} alt="score" />}
+        {scores && <ScoreRenderer scores={scores} definition={definition} />}
         {isCurated && <Tag color="green">Curated</Tag>}
         {hasPendingCurations && <Tag color="gold">Pending Curations</Tag>}
         <ButtonGroup>

--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -1,0 +1,103 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import get from 'lodash/get'
+import Tooltip from 'antd/lib/tooltip'
+import { getBadgeUrl } from '../../../api/clearlyDefined'
+
+/**
+ * Renders a badge image, with a tooltip containing all the details about the score
+ */
+
+class ScoreRenderer extends Component {
+  static propTypes = {
+    score: PropTypes.object,
+    domain: PropTypes.object,
+    definition: PropTypes.object
+  }
+
+  renderScore = score => (
+    <Fragment>
+      <p>Total: {score.total}</p>
+      {Object.keys(score).includes('date') && <p>Date: {score.date}</p>}
+      {Object.keys(score).includes('source') && <p>Source: {score.source}</p>}
+      {Object.keys(score).includes('consistency') && <p>Consistency: {score.consistency}</p>}
+      {Object.keys(score).includes('declared') && <p>Declared: {score.declared}</p>}
+      {Object.keys(score).includes('discovered') && <p>Discovered: {score.discovered}</p>}
+      {Object.keys(score).includes('spdx') && <p>Spdx: {score.spdx}</p>}
+      {Object.keys(score).includes('texts') && <p>Texts: {score.texts}</p>}
+    </Fragment>
+  )
+
+  renderTooltipContent = () => {
+    const { domain, definition } = this.props
+    if (!domain) {
+      const describedScore = get(definition, 'described.score')
+      const describedToolScore = get(definition, 'described.toolScore')
+      const licensedScore = get(definition, 'licensed.score')
+      const licensedToolScore = get(definition, 'licensed.toolScore')
+      return (
+        <div className="ScoreRenderer">
+          <h2>Described</h2>
+          <div className="ScoreRenderer__domain">
+            <div className="ScoreRenderer__domain__section">
+              <h2>Score</h2>
+              {this.renderScore(describedScore)}
+            </div>
+            <div className="ScoreRenderer__domain__section">
+              <h2>Toolscore:</h2>
+              {this.renderScore(describedToolScore)}
+            </div>
+          </div>
+
+          <h2>Licensed</h2>
+          <div className="ScoreRenderer__domain">
+            <div className="ScoreRenderer__domain__section">
+              <h2>Score</h2>
+              {this.renderScore(licensedScore)}
+            </div>
+            <div className="ScoreRenderer__domain__section">
+              <h2>Toolscore</h2>
+              {this.renderScore(licensedToolScore)}
+            </div>
+          </div>
+        </div>
+      )
+    } else {
+      return (
+        <div className="ScoreRenderer">
+          <div className="ScoreRenderer__domain">
+            <div className="ScoreRenderer__domain__section">
+              <h2>Score</h2>
+              {this.renderScore(get(domain, 'score'))}
+            </div>
+            <div className="ScoreRenderer__domain__section">
+              <h2>Toolscore:</h2>
+              {this.renderScore(get(domain, 'toolScore'))}
+            </div>
+          </div>
+        </div>
+      )
+    }
+  }
+
+  render() {
+    const { domain, scores } = this.props
+    if (!domain && !scores) return null
+    console.log(JSON.stringify(this.props.domain))
+    return (
+      <Tooltip title={this.renderTooltipContent} key={this.renderTooltipContent} overlayStyle={{ width: '800px' }}>
+        <img
+          className="list-buttons"
+          src={
+            domain
+              ? getBadgeUrl(get(domain, 'toolScore.total'), get(domain, 'score.total'))
+              : getBadgeUrl(scores.tool, scores.effective)
+          }
+          alt="score"
+        />
+      </Tooltip>
+    )
+  }
+}
+
+export default ScoreRenderer

--- a/src/components/Navigation/Ui/TitleWithScore.js
+++ b/src/components/Navigation/Ui/TitleWithScore.js
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getBadgeUrl } from '../../../api/clearlyDefined'
-import get from 'lodash/get'
+import ScoreRenderer from './ScoreRenderer'
 
 class TitleWithScore extends Component {
   static propTypes = {
@@ -11,27 +10,11 @@ class TitleWithScore extends Component {
     domain: PropTypes.object
   }
 
-  constructor(props) {
-    super(props)
-    this.renderScore = this.renderScore.bind(this)
-  }
-
-  renderScore(domain) {
-    if (!domain) return null
-    return (
-      <img
-        className="list-buttons"
-        src={getBadgeUrl(get(domain, 'toolScore.total'), get(domain, 'score.total'))}
-        alt="score"
-      />
-    )
-  }
-
   render() {
     const { title, domain } = this.props
     return (
       <span>
-        {title} {this.renderScore(domain)}
+        {title} <ScoreRenderer domain={domain} />
       </span>
     )
   }

--- a/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
+++ b/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ScoreRenderer from '../ScoreRenderer'
+
+const definition = {
+  described: {
+    toolScore: { total: 100, date: 30, source: 70 },
+    score: { total: 100, date: 30, source: 70 }
+  },
+  licensed: {
+    toolScore: { total: 68, declared: 30, discovered: 8, consistency: 15, spdx: 15, texts: 0 },
+    score: { total: 53, declared: 30, discovered: 8, consistency: 0, spdx: 15, texts: 0 }
+  }
+}
+const scores = { tool: 84, effective: 77 }
+const domain = {
+  toolScore: { total: 100, date: 30, source: 70 },
+  score: { total: 100, date: 30, source: 70 }
+}
+
+describe('ScoreRenderer', () => {
+  it('renders without crashing', () => {
+    shallow(<ScoreRenderer />)
+  })
+  it('renders with scores and definition', () => {
+    shallow(<ScoreRenderer scores={scores} definition={definition} />)
+  })
+  it('renders with domain', () => {
+    shallow(<ScoreRenderer domain={domain} />)
+  })
+})

--- a/src/styles/_ScoreRenderer.scss
+++ b/src/styles/_ScoreRenderer.scss
@@ -1,0 +1,24 @@
+.ScoreRenderer {
+  width: 100%;
+  padding: 10px;
+  h2 {
+    color: white;
+    font-size: 16px;
+  }
+  .ScoreRenderer__domain {
+    display: flex;
+    width: 300px;
+  }
+  .ScoreRenderer__domain__section {
+    padding: 20px;
+    width: 100%;
+    p {
+      font-size: 12px;
+      margin: 0;
+      padding: 0;
+    }
+  }
+}
+.ant-tooltip-inner {
+  width: 300px !important;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -52,3 +52,4 @@ main {
 @import './FacetsEditor.scss';
 @import './LicenseRenderer.scss';
 @import './Suggestions.scss';
+@import './ScoreRenderer.scss';


### PR DESCRIPTION
This one fixes #385

A tooltip has been added on the Score badge, showing content based on the situation.

When hovering a general score badge:
![schermata 2019-01-24 alle 18 21 17](https://user-images.githubusercontent.com/7654979/51696082-f2faee00-2004-11e9-8d35-7d8fd98d9bb4.png)

When hovering a specific score badge:
![schermata 2019-01-24 alle 18 21 25](https://user-images.githubusercontent.com/7654979/51696081-f2faee00-2004-11e9-9ba9-3ad270322421.png)
