### PR TITLE
only pass template option if using template renderer (fixes #447)

### DIFF
--- a/src/components/Navigation/Ui/SavePopUp.js
+++ b/src/components/Navigation/Ui/SavePopUp.js
@@ -40,7 +40,8 @@ export default class SavePopUp extends Component {
   }
 
   doOK = () => {
-    let { filename, renderer } = this.state
+    let { filename, renderer, template } = this.state
+    let options = {}
     switch (this.props.type) {
       case 'file':
       case 'gist':
@@ -48,10 +49,11 @@ export default class SavePopUp extends Component {
         break
       case 'notice':
         filename = this.ensureExtension(filename, extensions[renderer])
+        if (renderer === 'template') options.template = template
         break
       default:
     }
-    this.props.onOK({ filename, renderer, options: { template: this.state.template } })
+    this.props.onOK({ filename, renderer, options })
   }
 
   ensureExtension(name, extension) {


### PR DESCRIPTION
the default chive HTML template was always being overridden by the template we default for the other renderer.

Both renderers take a template option, but we only want to send a custom one for the template renderer the way the ui is setup right now