### PR TITLE
Test for License validation

### DIFF
--- a/src/components/LicensePicker/__tests__/LicensePickerUtils.test.unit.js
+++ b/src/components/LicensePicker/__tests__/LicensePickerUtils.test.unit.js
@@ -1,4 +1,6 @@
 import LicensePickerUtils from '../utils'
+import valid from 'spdx-expression-validate'
+import parse from 'spdx-expression-parse'
 
 const testRules = {
   left: { license: 'Apache-2.0' },
@@ -14,5 +16,19 @@ describe('LicensePickerUtils', () => {
   it('parse a definition with no license', () => {
     const licenseString = LicensePickerUtils.parseLicense('NOASSERTION')
     expect(licenseString).toEqual({ license: 'NOASSERTION' })
+  })
+  it('validate a license', () => {
+    const license = 'MIT-0'
+    const licenseParsed = parse(license)
+    const licenseValid = valid(license)
+    expect(licenseParsed).toEqual({ license })
+    expect(licenseValid).toBe(true)
+  })
+  it('validate a license', () => {
+    const license = 'MIT-CMU'
+    const licenseParsed = parse(license)
+    const licenseValid = valid(license)
+    expect(licenseParsed).toEqual({ license })
+    expect(licenseValid).toBe(true)
   })
 })


### PR DESCRIPTION
I've wrote a test to address the problem of validation mentioned in #412 

The test is failing when the library tries to validate a 'MIT-0' license, while passing without any issue if checking 'MIT-CMU'