### PR TITLE
License picker ui updates

### DIFF
--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -15,7 +15,6 @@ import nuget from '../images/nuget.svg'
 import Contribution from '../utils/contribution'
 import Definition from '../utils/definition'
 import EntitySpec from '../utils/entitySpec'
-import LicensePicker from './LicensePicker'
 
 export default class DefinitionEntry extends React.Component {
   static propTypes = {
@@ -196,14 +195,14 @@ export default class DefinitionEntry extends React.Component {
             <Col md={10} className="definition__line">
               {this.renderWithToolTipIfDifferent(
                 'licensed.declared',
-                <ModalEditor
+                <InlineEditor
                   field={'licensed.declared'}
                   extraClass={this.classIfDifferent('licensed.declared')}
                   readOnly={readOnly}
                   initialValue={this.getOriginalValue('licensed.declared')}
                   value={this.getValue('licensed.declared')}
                   onChange={this.fieldChange('licensed.declared')}
-                  editor={LicensePicker}
+                  type="license"
                   validator={value => true}
                   placeholder={'SPDX license'}
                   revertable

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -15,6 +15,7 @@ import nuget from '../images/nuget.svg'
 import Contribution from '../utils/contribution'
 import Definition from '../utils/definition'
 import EntitySpec from '../utils/entitySpec'
+import LicensesRenderer from './LicensesRenderer'
 
 export default class DefinitionEntry extends React.Component {
   static propTypes = {
@@ -187,6 +188,7 @@ export default class DefinitionEntry extends React.Component {
     const unlicensedPercent = totalFiles ? this.getPercentage(unlicensed, totalFiles) : '-'
     const unattributedPercent = totalFiles ? this.getPercentage(unattributed, totalFiles) : '-'
     const { readOnly, onRevert } = this.props
+
     return (
       <Row>
         <Col md={5}>
@@ -195,16 +197,12 @@ export default class DefinitionEntry extends React.Component {
             <Col md={10} className="definition__line">
               {this.renderWithToolTipIfDifferent(
                 'licensed.declared',
-                <InlineEditor
+                <LicensesRenderer
                   field={'licensed.declared'}
-                  extraClass={this.classIfDifferent('licensed.declared')}
                   readOnly={readOnly}
                   initialValue={this.getOriginalValue('licensed.declared')}
                   value={this.getValue('licensed.declared')}
                   onChange={this.fieldChange('licensed.declared')}
-                  type="license"
-                  validator={value => true}
-                  placeholder={'SPDX license'}
                   revertable
                   onRevert={() => onRevert('licensed.declared')}
                 />

--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -115,15 +115,9 @@ export default class FileList extends Component {
             <LicensesRenderer
               field={`files[${row.original.id}].license`}
               readOnly={readOnly}
-              isDifferent={Contribution.ifDifferent(
-                component,
-                previewDefinition,
-                `files[${row.original.id}].license`,
-                true,
-                false
-              )}
+              initialValue={get(component.item, `files[${row.original.id}].license`)}
               value={Contribution.getValue(component.item, previewDefinition, `files[${row.original.id}].license`)}
-              onSave={license => {
+              onChange={license => {
                 this.props.onChange(`files[${row.original.id}]`, license, null, license => {
                   const attributions = Contribution.getValue(
                     component.item,

--- a/src/components/InlineEditor.js
+++ b/src/components/InlineEditor.js
@@ -104,7 +104,7 @@ class InlineEditor extends React.Component {
   editors = {
     text: value => <input size="45" type="text" defaultValue={value} />,
     date: value => <input size="45" type="date" defaultValue={value} />,
-    license: value => <SpdxPicker value={value} />
+    license: value => <SpdxPicker value={value} autoFocus={true} />
   }
 
   editorDefaults = {

--- a/src/components/LicensesRenderer.js
+++ b/src/components/LicensesRenderer.js
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import ModalEditor from './ModalEditor'
-import LicensePicker from './LicensePicker'
+import InlineEditor from './InlineEditor'
 
 /**
  * Specific renderer for Licenses data
@@ -15,7 +14,7 @@ class LicensesRenderer extends Component {
     const { value, isDifferent, onSave, readOnly, field } = this.props
 
     return (
-      <ModalEditor
+      <InlineEditor
         field={field}
         extraClass={isDifferent ? 'license--isEdited' : ''}
         readOnly={readOnly}
@@ -26,7 +25,6 @@ class LicensesRenderer extends Component {
         validator
         placeholder={readOnly ? '' : 'SPDX License'}
         revertable={false}
-        editor={LicensePicker}
       />
     )
   }

--- a/src/components/LicensesRenderer.js
+++ b/src/components/LicensesRenderer.js
@@ -1,31 +1,67 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import InlineEditor from './InlineEditor'
+import { InlineEditor } from './'
+import { Modal } from 'react-bootstrap'
+import LicensePicker from './LicensePicker'
 
 /**
  * Specific renderer for Licenses data
- * It show a string of data, and if clicked opens a Popover containing a list of details
+ * It show a string of data, and if clicked allows user to edit inline
+ * An advanced view will open a modal with an expression builder
  *
  */
 class LicensesRenderer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      advancedView: false
+    }
+    this.toggleAdvancedView = this.toggleAdvancedView.bind(this)
+    this.advancedPickerChange = this.advancedPickerChange.bind(this)
+  }
+
+  toggleAdvancedView() {
+    this.setState(prevState => {
+      return { advancedView: !prevState.advancedView }
+    })
+  }
+
+  advancedPickerChange(spec, onChange) {
+    onChange(spec)
+    this.setState({ advancedView: false })
+  }
+
   render() {
-    const { value, isDifferent, onSave, readOnly, field } = this.props
+    const { extraClass, field, initialValue, onChange, onRevert, onSave, readOnly, revertable, value } = this.props
+    const { advancedView } = this.state
 
     return (
-      <InlineEditor
-        field={field}
-        extraClass={isDifferent ? 'license--isEdited' : ''}
-        readOnly={readOnly}
-        type={'license'}
-        initialValue={value}
-        value={value}
-        onChange={value => onSave(value)}
-        validator
-        placeholder={readOnly ? '' : 'SPDX License'}
-        revertable={false}
-      />
+      <div class="license-renderer">
+        <InlineEditor
+          field={field}
+          extraClass={extraClass}
+          readOnly={readOnly}
+          initialValue={initialValue}
+          value={value}
+          onChange={onChange}
+          onSave={onSave}
+          validator={() => true}
+          placeholder="SPDX license"
+          revertable={revertable}
+          onRevert={onRevert}
+          type="license"
+        />
+        <i className="fas fa-eye license-advanced" onClick={this.toggleAdvancedView} />
+        <Modal show={advancedView} onHide={this.toggleAdvancedView}>
+          <LicensePicker
+            onChange={spec => this.advancedPickerChange(spec, onChange)}
+            onClose={this.toggleAdvancedView}
+            value={value}
+          />
+        </Modal>
+      </div>
     )
   }
 }
@@ -35,7 +71,7 @@ LicensesRenderer.propTypes = {
    * item to show
    */
   value: PropTypes.string.isRequired,
-  isDifferent: PropTypes.bool,
+  extraClass: PropTypes.string,
   onSave: PropTypes.func,
   readOnly: PropTypes.bool,
   field: PropTypes.string

--- a/src/components/SpdxPicker.js
+++ b/src/components/SpdxPicker.js
@@ -7,7 +7,9 @@ import { Typeahead } from 'react-bootstrap-typeahead'
 import spdxLicenseIds from 'spdx-license-ids'
 import deprecatedSpdxLicenseIds from 'spdx-license-ids/deprecated'
 import { customLicenseIds } from '../utils/utils'
+
 const identifiers = [...customLicenseIds, ...spdxLicenseIds.sort(), ...deprecatedSpdxLicenseIds.sort()]
+
 export default class SpdxPicker extends Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
@@ -36,11 +38,10 @@ export default class SpdxPicker extends Component {
 
   render() {
     const { value, onBlur, onChange } = this.props
-    console.log(value)
     return (
       <div className="editable-editor">
         <Typeahead
-          selected={[value] || []}
+          defaultInputValue={value}
           options={identifiers}
           onBlur={onBlur}
           onKeyDown={e => this.onKeyPress(e, onChange)}
@@ -48,6 +49,7 @@ export default class SpdxPicker extends Component {
           ref={ref => (this._typeahead = ref)}
           bodyContainer
           highlightOnlyResult
+          autoFocus
           selectHintOnEnter
           clearButton
         />

--- a/src/components/SpdxPicker.js
+++ b/src/components/SpdxPicker.js
@@ -37,7 +37,7 @@ export default class SpdxPicker extends Component {
   }
 
   render() {
-    const { value, onBlur, onChange } = this.props
+    const { value, onBlur, onChange, autoFocus } = this.props
     return (
       <div className="editable-editor">
         <Typeahead
@@ -49,7 +49,7 @@ export default class SpdxPicker extends Component {
           ref={ref => (this._typeahead = ref)}
           bodyContainer
           highlightOnlyResult
-          autoFocus
+          autoFocus={autoFocus}
           selectHintOnEnter
           clearButton
         />

--- a/src/styles/_LicenseRenderer.scss
+++ b/src/styles/_LicenseRenderer.scss
@@ -3,3 +3,14 @@
   color: white;
   padding: 10px;
 }
+
+.license-renderer {
+  & > div {
+    float: left;
+  }
+  .license-advanced {
+    font-size: 1.2rem;
+    margin-left: 7px;
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
This change will let the user use the inline editor for editing licenses, but launch the license picker if they want to use the expression builder.