### PR TITLE
add build-dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "start:local-api": "env-cmd --fallback ./.env.localhost npm run build-scripts",
     "start:prod-api": "env-cmd --fallback ./.env.production npm run build-scripts",
     "build": "env-cmd --fallback ./.env.production npm run build-css && npm run copy-monaco && react-scripts build",
+    "build-dev": "env-cmd --fallback ./.env.development npm run build-css && npm run copy-monaco && react-scripts build",
     "test": "eslint --fix src && react-scripts test --env=jsdom --coverage",
     "test:unit": "jest -c jest.config.unit.js",
     "test:integration": "jest -c jest.config.integration.js",


### PR DESCRIPTION
this enables the PR environments to be built against the dev api instead of the prod api