### PR TITLE
E2E: Added back timeouts to test suites

### DIFF
--- a/e2e/tests/definitions.js
+++ b/e2e/tests/definitions.js
@@ -50,7 +50,7 @@ describe('Definitions page', () => {
     await expect(page).toMatchElement(definitionsMap.component.switchButton)
     await expect(page).toMatchElement(definitionsMap.component.revertButton)
     await expect(page).toMatchElement(definitionsMap.component.removeButton)
-  })
+  }, 20000)
 
   test('should display the detail after clicking on a component in the list', async () => {
     await page.waitForSelector(definitionsMap.component.firstElement)
@@ -74,7 +74,7 @@ describe('Definitions page', () => {
     const filesElement = await page.$(definitionsMap.component.details.files)
     const filesContent = await (await filesElement.getProperty('textContent')).jsonValue()
     await expect(filesContent).toMatch('Files')
-  })
+  }, 20000)
 
   test('should edit a license of a component in the list', async () => {
     await page.waitForSelector(definitionsMap.component.details.licensePickerButton)
@@ -91,7 +91,7 @@ describe('Definitions page', () => {
     await expect(page).toClick(definitionsMap.licensePicker.listSelection)
     await expect(page).toClick(definitionsMap.licensePicker.buttonSuccess)
     await expect(page).toMatchElement(definitionsMap.component.details.licenseFieldUpdated)
-  })
+  }, 20000)
 
   test('should open a modal while attempt to change a source location of a component in the list', async () => {
     await page.waitForSelector(definitionsMap.component.details.sourceField)
@@ -105,14 +105,14 @@ describe('Definitions page', () => {
     await expect(page).toMatchElement(definitionsMap.sourcePicker.identifier, { hidden: true })
     const hiddenSourcePickerModal = await page.$(definitionsMap.sourcePicker.identifier)
     await expect(hiddenSourcePickerModal).toBeNull()
-  })
+  }, 20000)
 
   test('should show an input field while attempting to change the release date of a component in the list', async () => {
     await page.waitForSelector(definitionsMap.component.details.releaseDateField)
     await expect(page).toMatchElement(definitionsMap.component.details.releaseDateField)
     await expect(page).toClick(definitionsMap.component.details.releaseDateField)
     await expect(page).toMatchElement(definitionsMap.component.details.releaseDateInput)
-  })
+  }, 20000)
 
   test('should display a modal after clicking on the inspect button of a definition the list', async () => {
     await page.waitForSelector(definitionsMap.component.inspectButton)
@@ -122,7 +122,7 @@ describe('Definitions page', () => {
     await expect(page).toMatchElement(definitionsMap.fullDetailView.identifier)
     await expect(page).toMatchElement(definitionsMap.fullDetailView.buttonSuccess)
     await expect(page).toClick(definitionsMap.fullDetailView.buttonSuccess)
-  })
+  }, 20000)
 
   test('should open the contribution modal', async () => {
     await page.waitForSelector(definitionsMap.contributeButton)
@@ -139,5 +139,5 @@ describe('Definitions page', () => {
     await expect(page).toClick(definitionsMap.contributeModal.contributeButton)
     await page.waitForSelector(definitionsMap.contributeSuccess)
     await expect(page).toMatchElement(definitionsMap.contributeSuccess, { timeout: 30000 })
-  })
+  }, 20000)
 })

--- a/e2e/tests/definitions.js
+++ b/e2e/tests/definitions.js
@@ -1,143 +1,150 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 import { definitionsMap } from '../maps/definitions'
-const puppeteer = require('puppeteer')
+import { setDefaultOptions } from 'expect-puppeteer'
 
+const puppeteer = require('puppeteer')
+const defaultTimeout = process.env.JEST_TIMEOUT ? process.env.JEST_TIMEOUT : 30000
+
+setDefaultOptions({ timeout: defaultTimeout })
 let browser
 let page
 
-describe('Definitions page', () => {
-  beforeAll(async () => {
-    if (process.env.JEST_TIMEOUT) jest.setTimeout(process.env.JEST_TIMEOUT)
-    browser = await puppeteer.launch({ headless: process.env.NODE_ENV !== 'debug', slowMo: 80 })
-    page = await browser.newPage()
-    if (process.env.JEST_TIMEOUT) page.setDefaultTimeout(process.env.JEST_TIMEOUT)
-    await page.setViewport({ width: 1920, height: 1080 })
-    await page.goto(`${__HOST__}/definitions`, { waitUntil: 'domcontentloaded' })
-  })
+describe(
+  'Definitions page',
+  () => {
+    beforeAll(async () => {
+      jest.setTimeout(defaultTimeout)
+      browser = await puppeteer.launch({ headless: process.env.NODE_ENV !== 'debug', slowMo: 80 })
+      page = await browser.newPage()
+      await page.setViewport({ width: 1920, height: 1080 })
+      await page.goto(`${__HOST__}/definitions`, { waitUntil: 'domcontentloaded' })
+    })
 
-  afterAll(() => {
-    browser.close()
-  })
+    afterAll(() => {
+      browser.close()
+    })
 
-  it('should display "Available definitions" text on page', async () => {
-    await page.waitForSelector('.section-title')
-    await expect(page).toMatch('Available definitions')
-  })
+    it('should display "Available definitions" text on page', async () => {
+      await page.waitForSelector('.section-title')
+      await expect(page).toMatch('Available definitions')
+    })
 
-  test('user can type a definition text and should display a component in the list', async () => {
-    await page.waitForSelector(definitionsMap.componentSearch.input)
-    await expect(page).toMatchElement(definitionsMap.componentSearch.input)
-    await expect(page).toClick(definitionsMap.componentSearch.input)
-    await page.type(definitionsMap.componentSearch.input, 'async')
-    await page.waitFor(2000)
-    await expect(page).toMatchElement(definitionsMap.componentSearch.list)
-    let element = await page.$(definitionsMap.componentSearch.listElement)
-    element.click()
-    await expect(page).toMatchElement(definitionsMap.componentList.list)
-    await expect(page).toMatchElement(
-      `${definitionsMap.componentList.list} ${definitionsMap.componentList.firstElement}`
-    )
-    const componentTitle = await page.$(definitionsMap.component.name)
-    const text = await (await componentTitle.getProperty('textContent')).jsonValue()
-    await expect(text).toMatch('async')
-    await page.waitForSelector(definitionsMap.component.image)
-    await expect(page).toMatchElement(definitionsMap.component.image)
-    await expect(page).toMatchElement(definitionsMap.component.buttons)
-    await expect(page).toMatchElement(definitionsMap.component.sourceButton)
-    await expect(page).toMatchElement(definitionsMap.component.inspectButton)
-    await expect(page).toMatchElement(definitionsMap.component.copyButton)
-    await expect(page).toMatchElement(definitionsMap.component.switchButton)
-    await expect(page).toMatchElement(definitionsMap.component.revertButton)
-    await expect(page).toMatchElement(definitionsMap.component.removeButton)
-  }, 20000)
+    test('user can type a definition text and should display a component in the list', async () => {
+      await page.waitForSelector(definitionsMap.componentSearch.input)
+      await expect(page).toMatchElement(definitionsMap.componentSearch.input)
+      await expect(page).toClick(definitionsMap.componentSearch.input)
+      await page.type(definitionsMap.componentSearch.input, 'async')
+      await page.waitFor(2000)
+      await expect(page).toMatchElement(definitionsMap.componentSearch.list)
+      let element = await page.$(definitionsMap.componentSearch.listElement)
+      element.click()
+      await expect(page).toMatchElement(definitionsMap.componentList.list)
+      await expect(page).toMatchElement(
+        `${definitionsMap.componentList.list} ${definitionsMap.componentList.firstElement}`
+      )
+      const componentTitle = await page.$(definitionsMap.component.name)
+      const text = await (await componentTitle.getProperty('textContent')).jsonValue()
+      await expect(text).toMatch('async')
+      await page.waitForSelector(definitionsMap.component.image)
+      await expect(page).toMatchElement(definitionsMap.component.image)
+      await expect(page).toMatchElement(definitionsMap.component.buttons)
+      await expect(page).toMatchElement(definitionsMap.component.sourceButton)
+      await expect(page).toMatchElement(definitionsMap.component.inspectButton)
+      await expect(page).toMatchElement(definitionsMap.component.copyButton)
+      await expect(page).toMatchElement(definitionsMap.component.switchButton)
+      await expect(page).toMatchElement(definitionsMap.component.revertButton)
+      await expect(page).toMatchElement(definitionsMap.component.removeButton)
+    })
 
-  test('should display the detail after clicking on a component in the list', async () => {
-    await page.waitForSelector(definitionsMap.component.firstElement)
-    await expect(page).toClick(definitionsMap.component.firstElement)
-    await expect(page).toMatchElement(definitionsMap.component.panel)
-    const declaredElement = await page.$(definitionsMap.component.details.declared)
-    const declaredContent = await (await declaredElement.getProperty('textContent')).jsonValue()
-    await expect(declaredContent).toMatch('Declared')
-    const sourceElement = await page.$(definitionsMap.component.details.source)
-    const sourceContent = await (await sourceElement.getProperty('textContent')).jsonValue()
-    await expect(sourceContent).toMatch('Source')
-    const releaseElement = await page.$(definitionsMap.component.details.releaseDate)
-    const releaseContent = await (await releaseElement.getProperty('textContent')).jsonValue()
-    await expect(releaseContent).toMatch('Release')
-    const discoveredElement = await page.$(definitionsMap.component.details.discovered)
-    const discoveredContent = await (await discoveredElement.getProperty('textContent')).jsonValue()
-    await expect(discoveredContent).toMatch('Discovered')
-    const attributionElement = await page.$(definitionsMap.component.details.attribution)
-    const attributionContent = await (await attributionElement.getProperty('textContent')).jsonValue()
-    await expect(attributionContent).toMatch('Attribution')
-    const filesElement = await page.$(definitionsMap.component.details.files)
-    const filesContent = await (await filesElement.getProperty('textContent')).jsonValue()
-    await expect(filesContent).toMatch('Files')
-  }, 20000)
+    test('should display the detail after clicking on a component in the list', async () => {
+      await page.waitForSelector(definitionsMap.component.firstElement)
+      await expect(page).toClick(definitionsMap.component.firstElement)
+      await expect(page).toMatchElement(definitionsMap.component.panel)
+      const declaredElement = await page.$(definitionsMap.component.details.declared)
+      const declaredContent = await (await declaredElement.getProperty('textContent')).jsonValue()
+      await expect(declaredContent).toMatch('Declared')
+      const sourceElement = await page.$(definitionsMap.component.details.source)
+      const sourceContent = await (await sourceElement.getProperty('textContent')).jsonValue()
+      await expect(sourceContent).toMatch('Source')
+      const releaseElement = await page.$(definitionsMap.component.details.releaseDate)
+      const releaseContent = await (await releaseElement.getProperty('textContent')).jsonValue()
+      await expect(releaseContent).toMatch('Release')
+      const discoveredElement = await page.$(definitionsMap.component.details.discovered)
+      const discoveredContent = await (await discoveredElement.getProperty('textContent')).jsonValue()
+      await expect(discoveredContent).toMatch('Discovered')
+      const attributionElement = await page.$(definitionsMap.component.details.attribution)
+      const attributionContent = await (await attributionElement.getProperty('textContent')).jsonValue()
+      await expect(attributionContent).toMatch('Attribution')
+      const filesElement = await page.$(definitionsMap.component.details.files)
+      const filesContent = await (await filesElement.getProperty('textContent')).jsonValue()
+      await expect(filesContent).toMatch('Files')
+    })
 
-  test('should edit a license of a component in the list', async () => {
-    await page.waitForSelector(definitionsMap.component.details.licensePickerButton)
-    await expect(page).toMatchElement(definitionsMap.component.details.licensePickerButton)
-    await expect(page).toClick(definitionsMap.component.details.licensePickerButton)
-    await expect(page).toMatchElement(definitionsMap.licensePicker.identifier)
+    test('should edit a license of a component in the list', async () => {
+      await page.waitForSelector(definitionsMap.component.details.licensePickerButton)
+      await expect(page).toMatchElement(definitionsMap.component.details.licensePickerButton)
+      await expect(page).toClick(definitionsMap.component.details.licensePickerButton)
+      await expect(page).toMatchElement(definitionsMap.licensePicker.identifier)
 
-    const inputValue = await page.$eval(definitionsMap.licensePicker.inputField, el => el.value)
-    await expect(page).toClick(definitionsMap.licensePicker.inputField, 'MIT')
-    for (let i = 0; i < inputValue.length; i++) {
-      await page.keyboard.press('Backspace')
-    }
-    await page.type(definitionsMap.licensePicker.inputField, 'MIT')
-    await expect(page).toClick(definitionsMap.licensePicker.listSelection)
-    await expect(page).toClick(definitionsMap.licensePicker.buttonSuccess)
-    await expect(page).toMatchElement(definitionsMap.component.details.licenseFieldUpdated)
-  }, 20000)
+      const inputValue = await page.$eval(definitionsMap.licensePicker.inputField, el => el.value)
+      await expect(page).toClick(definitionsMap.licensePicker.inputField, 'MIT')
+      for (let i = 0; i < inputValue.length; i++) {
+        await page.keyboard.press('Backspace')
+      }
+      await page.type(definitionsMap.licensePicker.inputField, 'MIT')
+      await expect(page).toClick(definitionsMap.licensePicker.listSelection)
+      await expect(page).toClick(definitionsMap.licensePicker.buttonSuccess)
+      await expect(page).toMatchElement(definitionsMap.component.details.licenseFieldUpdated)
+    })
 
-  test('should open a modal while attempt to change a source location of a component in the list', async () => {
-    await page.waitForSelector(definitionsMap.component.details.sourceField)
-    await expect(page).toMatchElement(definitionsMap.component.details.sourceField)
-    await expect(page).toClick(definitionsMap.component.details.sourceField)
-    await expect(page).toMatchElement(definitionsMap.sourcePicker.identifier)
-    const sourcePickerModal = await page.$(definitionsMap.sourcePicker.identifier)
-    await expect(sourcePickerModal).not.toBeNull()
-    await expect(page).toMatchElement(definitionsMap.sourcePicker.buttonSuccess)
-    await expect(page).toClick(definitionsMap.sourcePicker.buttonSuccess)
-    await expect(page).toMatchElement(definitionsMap.sourcePicker.identifier, { hidden: true })
-    const hiddenSourcePickerModal = await page.$(definitionsMap.sourcePicker.identifier)
-    await expect(hiddenSourcePickerModal).toBeNull()
-  }, 20000)
+    test('should open a modal while attempt to change a source location of a component in the list', async () => {
+      await page.waitForSelector(definitionsMap.component.details.sourceField)
+      await expect(page).toMatchElement(definitionsMap.component.details.sourceField)
+      await expect(page).toClick(definitionsMap.component.details.sourceField)
+      await expect(page).toMatchElement(definitionsMap.sourcePicker.identifier)
+      const sourcePickerModal = await page.$(definitionsMap.sourcePicker.identifier)
+      await expect(sourcePickerModal).not.toBeNull()
+      await expect(page).toMatchElement(definitionsMap.sourcePicker.buttonSuccess)
+      await expect(page).toClick(definitionsMap.sourcePicker.buttonSuccess)
+      await expect(page).toMatchElement(definitionsMap.sourcePicker.identifier, { hidden: true })
+      const hiddenSourcePickerModal = await page.$(definitionsMap.sourcePicker.identifier)
+      await expect(hiddenSourcePickerModal).toBeNull()
+    })
 
-  test('should show an input field while attempting to change the release date of a component in the list', async () => {
-    await page.waitForSelector(definitionsMap.component.details.releaseDateField)
-    await expect(page).toMatchElement(definitionsMap.component.details.releaseDateField)
-    await expect(page).toClick(definitionsMap.component.details.releaseDateField)
-    await expect(page).toMatchElement(definitionsMap.component.details.releaseDateInput)
-  }, 20000)
+    test('should show an input field while attempting to change the release date of a component in the list', async () => {
+      await page.waitForSelector(definitionsMap.component.details.releaseDateField)
+      await expect(page).toMatchElement(definitionsMap.component.details.releaseDateField)
+      await expect(page).toClick(definitionsMap.component.details.releaseDateField)
+      await expect(page).toMatchElement(definitionsMap.component.details.releaseDateInput)
+    })
 
-  test('should display a modal after clicking on the inspect button of a definition the list', async () => {
-    await page.waitForSelector(definitionsMap.component.inspectButton)
-    await expect(page).toMatchElement(definitionsMap.component.inspectButton)
-    await expect(page).toClick(definitionsMap.component.inspectButton)
-    await page.waitForSelector(definitionsMap.fullDetailView.identifier)
-    await expect(page).toMatchElement(definitionsMap.fullDetailView.identifier)
-    await expect(page).toMatchElement(definitionsMap.fullDetailView.buttonSuccess)
-    await expect(page).toClick(definitionsMap.fullDetailView.buttonSuccess)
-  }, 20000)
+    test('should display a modal after clicking on the inspect button of a definition the list', async () => {
+      await page.waitForSelector(definitionsMap.component.inspectButton)
+      await expect(page).toMatchElement(definitionsMap.component.inspectButton)
+      await expect(page).toClick(definitionsMap.component.inspectButton)
+      await page.waitForSelector(definitionsMap.fullDetailView.identifier)
+      await expect(page).toMatchElement(definitionsMap.fullDetailView.identifier)
+      await expect(page).toMatchElement(definitionsMap.fullDetailView.buttonSuccess)
+      await expect(page).toClick(definitionsMap.fullDetailView.buttonSuccess)
+    })
 
-  test('should open the contribution modal', async () => {
-    await page.waitForSelector(definitionsMap.contributeButton)
-    await expect(page).toMatchElement(definitionsMap.contributeButton)
-    await expect(page).toClick(definitionsMap.contributeButton)
-    await page.waitForSelector(definitionsMap.contributeModal.identifier)
-    await expect(page).toFill(definitionsMap.contributeModal.summaryField, 'AUTOMATION TEST')
-    await expect(page).toFill(definitionsMap.contributeModal.detailsField, 'AUTOMATION TEST')
-    await expect(page).toFill(definitionsMap.contributeModal.resolutionField, 'AUTOMATION TEST')
-    await page.waitForSelector(definitionsMap.contributeModal.typeField)
-    await page.select(definitionsMap.contributeModal.typeField, 'missing')
-    await page.waitForSelector(definitionsMap.contributeButton)
-    await expect(page).toMatchElement(definitionsMap.contributeModal.contributeButton)
-    await expect(page).toClick(definitionsMap.contributeModal.contributeButton)
-    await page.waitForSelector(definitionsMap.contributeSuccess)
-    await expect(page).toMatchElement(definitionsMap.contributeSuccess, { timeout: 30000 })
-  }, 20000)
-})
+    test('should open the contribution modal', async () => {
+      await page.waitForSelector(definitionsMap.contributeButton)
+      await expect(page).toMatchElement(definitionsMap.contributeButton)
+      await expect(page).toClick(definitionsMap.contributeButton)
+      await page.waitForSelector(definitionsMap.contributeModal.identifier)
+      await expect(page).toFill(definitionsMap.contributeModal.summaryField, 'AUTOMATION TEST')
+      await expect(page).toFill(definitionsMap.contributeModal.detailsField, 'AUTOMATION TEST')
+      await expect(page).toFill(definitionsMap.contributeModal.resolutionField, 'AUTOMATION TEST')
+      await page.waitForSelector(definitionsMap.contributeModal.typeField)
+      await page.select(definitionsMap.contributeModal.typeField, 'missing')
+      await page.waitForSelector(definitionsMap.contributeButton)
+      await expect(page).toMatchElement(definitionsMap.contributeModal.contributeButton)
+      await expect(page).toClick(definitionsMap.contributeModal.contributeButton)
+      await page.waitForSelector(definitionsMap.contributeSuccess)
+      await expect(page).toMatchElement(definitionsMap.contributeSuccess, { timeout: 30000 })
+    })
+  },
+  defaultTimeout
+)

--- a/src/components/Navigation/Ui/__tests__/EditableFieldRenderer.test.js
+++ b/src/components/Navigation/Ui/__tests__/EditableFieldRenderer.test.js
@@ -84,7 +84,7 @@ describe('EditableFieldRenderer', () => {
   it('check computedValues for field of type date', () => {
     const customProps = { ...props, type: 'date' }
     const wrapper = shallow(<EditableFieldRenderer {...customProps} />)
-    expect(wrapper.state()).toEqual({ computedValue: null, initialValue: null})
+    expect(wrapper.state()).toEqual({ computedValue: null, initialValue: null })
   })
   it('check computedValues for field of type coordinates', () => {
     const customProps = { ...props, type: 'coordinates' }


### PR DESCRIPTION
This fixes a problem when running E2E locally.

Apparently the jest.setTimeout() doesn't work as expected.
Adding back the timeouts to each single test do the trick.