### PR TITLE
improve perf of browseDefinitionsAction (fixes #528)

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -43,12 +43,10 @@ export const UI_CURATE_GET_DEFINITION_PROPOSED = 'UI_CURATE_GET_DEFINITION_PROPO
 export const UI_CURATE_DEFINITION_PREVIEW = 'UI_CURATE_DEFINITION_PREVIEW'
 export const UI_DEFINITION_REVERT = 'UI_DEFINITION_REVERT'
 
-export const UI_DEFINITIONS_GET = 'UI_DEFINITIONS_GET'
 export const UI_DEFINITIONS_UPDATE_FILTER = 'UI_DEFINITIONS_UPDATE_FILTER'
 export const UI_DEFINITIONS_UPDATE_FILTER_LIST = 'UI_DEFINITIONS_UPDATE_FILTER_LIST'
 export const UI_DEFINITIONS_UPDATE_LIST = 'UI_DEFINITIONS_UPDATE_LIST'
 
-export const UI_BROWSE_GET = 'UI_BROWSE_GET'
 export const UI_BROWSE_UPDATE_FILTER = 'UI_BROWSE_UPDATE_FILTER'
 export const UI_BROWSE_UPDATE_FILTER_LIST = 'UI_BROWSE_UPDATE_FILTER_LIST'
 export const UI_BROWSE_UPDATE_LIST = 'UI_BROWSE_UPDATE_LIST'
@@ -152,7 +150,7 @@ export function uiRevertDefinition(definition, values) {
 }
 
 export function uiBrowseGet(token, query) {
-  return browseDefinitionsAction(token, query, UI_BROWSE_GET)
+  return browseDefinitionsAction(token, query, UI_BROWSE_UPDATE_LIST)
 }
 
 export function uiBrowseUpdateFilter(value) {

--- a/src/reducers/listReducer.js
+++ b/src/reducers/listReducer.js
@@ -90,13 +90,6 @@ export default (name = '', transformer = null, comparator = null) => {
       }
     }
 
-    if (result.startQuery) {
-      return {
-        ...state,
-        isFetching: true
-      }
-    }
-
     if (result.add) {
       const newList = add(state.list, result.add, comparator)
       return {


### PR DESCRIPTION
we were dispatching an update for every definition we got back from the query.
There was also some unused code paths confusing things