### PR TITLE
normalize buttons to OK/Cancel

### DIFF
--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -152,9 +152,6 @@ export default class ContributePrompt extends Component {
                 Remove contributed definitions from the list
               </Checkbox>
               <FormGroup className="pull-right">
-                <Button data-test-id="cancel-button" onClick={this.close}>
-                  Cancel
-                </Button>
                 <Button
                   bsStyle="success"
                   data-test-id="contribute-button"
@@ -163,6 +160,9 @@ export default class ContributePrompt extends Component {
                   onClick={this.okHandler}
                 >
                   OK
+                </Button>
+                <Button data-test-id="cancel-button" onClick={this.close}>
+                  Cancel
                 </Button>
               </FormGroup>
             </div>

--- a/src/components/FullDetailView/FullDetailPage.js
+++ b/src/components/FullDetailView/FullDetailPage.js
@@ -162,8 +162,8 @@ export class FullDetailPage extends AbstractFullDetailsView {
             notification.close(key)
           }}
           onClose={() => notification.close(key)}
-          confirmText="Confirm"
-          dismissText="Dismiss Notification"
+          confirmText="OK"
+          dismissText="Cancel"
         />
       ),
       key,
@@ -194,8 +194,8 @@ export class FullDetailPage extends AbstractFullDetailsView {
             })
           }
           onClose={() => notification.close(key)}
-          confirmText="Confirm"
-          dismissText="Dismiss Notification"
+          confirmText="OK"
+          dismissText="Cancel"
         />
       ),
       key,

--- a/src/components/Navigation/Ui/VersionSelector.js
+++ b/src/components/Navigation/Ui/VersionSelector.js
@@ -81,10 +81,10 @@ class VersionSelector extends Component {
         </Modal.Body>
         <Modal.Footer>
           <FormGroup className="pull-right">
-            <Button onClick={this.onClose}>Cancel</Button>
             <Button bsStyle="success" type="button" disabled={selected.length === 0} onClick={() => this.doSave()}>
               OK
             </Button>
+            <Button onClick={this.onClose}>Cancel</Button>
           </FormGroup>
         </Modal.Footer>
       </Modal>

--- a/src/components/SourcePicker.js
+++ b/src/components/SourcePicker.js
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Grid, Row, Col, Button, ButtonGroup } from 'react-bootstrap'
+import { Grid, Row, Col, Button, ButtonGroup, FormGroup } from 'react-bootstrap'
 import { GitHubSelector, GitHubCommitPicker } from './'
 import { getGitHubRevisions } from '../api/clearlyDefined'
 import EntitySpec from '../utils/entitySpec'
@@ -46,14 +46,14 @@ class SourcePicker extends Component {
   }
 
   renderActionButton() {
+    const { onChange, onClose } = this.props
     return (
-      <Button
-        className="pull-right"
-        bsStyle="success"
-        onClick={() => this.props.onChange(this.state.selectedComponent)}
-      >
-        Select
-      </Button>
+      <FormGroup className="pull-right">
+        <Button bsStyle="success" onClick={() => onChange(this.state.selectedComponent)}>
+          OK
+        </Button>
+        <Button onClick={() => onClose()}>Cancel</Button>
+      </FormGroup>
     )
   }
 
@@ -72,14 +72,15 @@ class SourcePicker extends Component {
           <Col md={2}>{this.renderProviderButtons()}</Col>
           <Col md={5}>{activeProvider === 'github' && <GitHubSelector onChange={this.onSelectComponent} />}</Col>
           <Col md={5}>
-            {selectedComponent && activeProvider === 'github' && (
-              <GitHubCommitPicker
-                allowNew
-                request={selectedComponent}
-                getGitHubRevisions={path => getGitHubRevisions(this.props.token, path)}
-                onChange={this.commitChanged.bind(this, selectedComponent)}
-              />
-            )}
+            {selectedComponent &&
+              activeProvider === 'github' && (
+                <GitHubCommitPicker
+                  allowNew
+                  request={selectedComponent}
+                  getGitHubRevisions={path => getGitHubRevisions(this.props.token, path)}
+                  onChange={this.commitChanged.bind(this, selectedComponent)}
+                />
+              )}
           </Col>
         </Row>
         <Row className="spacer">

--- a/src/components/SystemManagedList.js
+++ b/src/components/SystemManagedList.js
@@ -291,8 +291,8 @@ export default class SystemManagedList extends Component {
             notification.close(key)
           }}
           onClose={() => notification.close(key)}
-          confirmText="Revert"
-          dismissText="Dismiss"
+          confirmText="OK"
+          dismissText="Cancel"
         />
       ),
       key,


### PR DESCRIPTION
Throughout the UI we should be using OK and Cancel (in that order) but we have a mix. This PR fixes the variations.

Note that for some reason in the SourcePicker I am unable to get the styling to have a space between the two buttons. Not sure what our convention is there and how it is happening elsewhere