### PR TITLE
clean up lint and runtime errors

### DIFF
--- a/src/components/LicensePicker/RuleBuilder.js
+++ b/src/components/LicensePicker/RuleBuilder.js
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ToggleButtonGroup, ToggleButton, Button, Row, Col } from 'react-bootstrap'
 import SpdxPicker from '../SpdxPicker'

--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -19,7 +19,6 @@ import FilterList from '../../Ui/FilterList'
 import SortList from '../../Ui/SortList'
 import ContributePrompt from '../../../ContributePrompt'
 import { licenses, curateFilters } from '../../../../utils/utils'
-import { stat } from 'fs'
 
 /**
  * Page that show to the user a list of interesting definitions to curate

--- a/src/components/Navigation/Pages/PageDefinitions/PageDefinitions.js
+++ b/src/components/Navigation/Pages/PageDefinitions/PageDefinitions.js
@@ -150,7 +150,7 @@ export class PageDefinitions extends UserManagedList {
 
   render() {
     const { components, curations, definitions, session, filterOptions } = this.props
-    const { sequence, showFullDetail, path, currentComponent, currentDefinition } = this.state
+    const { sequence, showFullDetail, path, currentComponent, currentDefinition, showSavePopup, saveType } = this.state
     return (
       <Grid className="main-container">
         <ContributePrompt
@@ -198,12 +198,14 @@ export class PageDefinitions extends UserManagedList {
             readOnly={this.readOnly}
           />
         )}
-        <SavePopUp
-          show={this.state.showSavePopup}
-          type={this.state.saveType}
-          onHide={() => this.setState({ showSavePopup: false })}
-          onOK={options => this.setState({ options }, this.doSave)}
-        />
+        {showSavePopup && (
+          <SavePopUp
+            show={showSavePopup}
+            type={saveType}
+            onHide={() => this.setState({ showSavePopup: false })}
+            onOK={options => this.setState({ options }, this.doSave)}
+          />
+        )}
         {this.renderVersionSelectopPopup()}
       </Grid>
     )

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -71,22 +71,24 @@ export default class ComponentButtons extends Component {
     return (
       <div className="list-activity-area">
         {isCurationPending && (
-          <a href="https://github.com/clearlydefined/curated-data/pulls" target="_blank">
+          <a href="https://github.com/clearlydefined/curated-data/pulls" target="_blank" rel="noopener noreferrer">
             <Tag color="green">Pending curations</Tag>
           </a>
         )}
         {scores && <ScoreRenderer scores={scores} definition={definition} />}
         <ButtonGroup>
-          {!isSourceComponent && !readOnly && !isSourceEmpty && (
-            <ButtonWithTooltip
-              name="addSourceComponent"
-              tip={'Add the definition for source that matches this package'}
-            >
-              <Button className="list-fa-button" onClick={this.addSourceForComponent.bind(this, component)}>
-                <i className="fas fa-code" />
-              </Button>
-            </ButtonWithTooltip>
-          )}
+          {!isSourceComponent &&
+            !readOnly &&
+            !isSourceEmpty && (
+              <ButtonWithTooltip
+                name="addSourceComponent"
+                tip={'Add the definition for source that matches this package'}
+              >
+                <Button className="list-fa-button" onClick={this.addSourceForComponent.bind(this, component)}>
+                  <i className="fas fa-code" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
           {!isDefinitionEmpty && (
             <ButtonWithTooltip tip={'Dig into this definition'}>
               <Button
@@ -132,17 +134,18 @@ export default class ComponentButtons extends Component {
               </div>
             </ButtonWithTooltip>
           )}
-          {!readOnly && !isDefinitionEmpty && (
-            <ButtonWithTooltip tip={'Revert Changes of this Definition'}>
-              <Button
-                className="list-fa-button"
-                onClick={() => this.revertComponent(component)}
-                disabled={!hasChange(component)}
-              >
-                <i className="fas fa-undo" />
-              </Button>
-            </ButtonWithTooltip>
-          )}
+          {!readOnly &&
+            !isDefinitionEmpty && (
+              <ButtonWithTooltip tip={'Revert Changes of this Definition'}>
+                <Button
+                  className="list-fa-button"
+                  onClick={() => this.revertComponent(component)}
+                  disabled={!hasChange(component)}
+                >
+                  <i className="fas fa-undo" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
         </ButtonGroup>
         {!readOnly && (
           <Button bsStyle="link" onClick={this.removeComponent.bind(this, component)}>

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { ROUTE_DEFINITIONS, ROUTE_HARVEST, ROUTE_ABOUT, ROUTE_BROWSE } from '../utils/routingConstants'
+import { ROUTE_DEFINITIONS, ROUTE_HARVEST, ROUTE_ABOUT } from '../utils/routingConstants'
 import {
   UI_NAVIGATION,
   UI_NOTIFICATION_NEW,

--- a/src/utils/definition.js
+++ b/src/utils/definition.js
@@ -5,7 +5,6 @@ import EntitySpec from './entitySpec'
 import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import isEmpty from 'lodash/isEmpty'
-import union from 'lodash/union'
 
 // Abstract methods for Definition
 export default class Definition {


### PR DESCRIPTION
There are a few errors and warnings that show up in the browser console when loading the /definitions page. This cleans them up.