### PR TITLE
Tweak Browse page UI

### DIFF
--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import { connect } from 'react-redux'
-import { Grid } from 'react-bootstrap'
+import { Row, Col, Grid } from 'react-bootstrap'
 import get from 'lodash/get'
 import uniq from 'lodash/uniq'
 import classNames from 'classnames'
@@ -51,15 +51,19 @@ class PageBrowse extends SystemManagedList {
   }
 
   tableTitle() {
+    return 'Browse Definitions'
+  }
+
+  renderTopFilters() {
     const providers = [
+      { value: 'cocoapods', label: 'CocoaPods' },
       { value: 'cratesio', label: 'Crates.io' },
       { value: 'github', label: 'GitHub' },
       { value: 'mavencentral', label: 'MavenCentral' },
       { value: 'npmjs', label: 'NpmJS' },
       { value: 'nuget', label: 'NuGet' },
       { value: 'pypi', label: 'PyPi' },
-      { value: 'rubygems', label: 'RubyGems' },
-      { value: 'cocoapods', label: 'CocoaPods' }
+      { value: 'rubygems', label: 'RubyGems' }
     ]
     const { filterOptions } = this.props
     const coordinates = filterOptions.list
@@ -68,20 +72,24 @@ class PageBrowse extends SystemManagedList {
     const names = uniq(coordinates.map(coordinate => coordinate.name))
     filterOptions.list = names
     return (
-      <div>
-        <span>Browse Definitions</span>
-        <div className={'horizontalBlock'}>
-          {this.renderFilter(providers, 'Provider', 'provider')}
+      <Row className="show-grid spacer">
+        <Col md={2} mdOffset={1}>
           {this.renderFilter(curateFilters, 'Curate', 'curate')}
-          <FilterBar
-            options={filterOptions}
-            onChange={this.onBrowse}
-            onSearch={this.onSearch}
-            onClear={this.onBrowse}
-            clearOnChange
-          />
-        </div>
-      </div>
+        </Col>
+        <Col md={8}>
+          <div className={'horizontalBlock'}>
+            {this.renderFilter(providers, 'Provider', 'provider')}
+            <span>&nbsp;</span>
+            <FilterBar
+              options={filterOptions}
+              onChange={this.onBrowse}
+              onSearch={this.onSearch}
+              onClear={this.onBrowse}
+              clearOnChange
+            />
+          </div>
+        </Col>
+      </Row>
     )
   }
 
@@ -197,6 +205,7 @@ class PageBrowse extends SystemManagedList {
           onLogin={this.handleLogin}
           actionHandler={this.doContribute}
         />
+        {this.renderTopFilters()}
         <Section className="flex-grow-column" name={this.tableTitle()} actionButton={this.renderButtons()}>
           {
             <div className={classNames('section-body flex-grow', { loading: components.isFetching })}>
@@ -206,10 +215,8 @@ class PageBrowse extends SystemManagedList {
                 list={components.transformedList}
                 listLength={get(components, 'headers.pagination.totalCount') || components.list.length}
                 loadMoreRows={this.loadMoreRows}
-                onRemove={this.onRemoveComponent}
                 onRevert={(definition, value) => this.revertDefinition(definition, value, 'browse')}
                 onChange={this.onChangeComponent}
-                onAddComponent={this.onAddComponent}
                 onInspect={this.onInspect}
                 renderFilterBar={this.renderFilterBar}
                 curations={curations}

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -57,7 +57,15 @@ export default class ComponentButtons extends Component {
   }
 
   render() {
-    const { definition, currentComponent, readOnly, hasChange, hideVersionSelector } = this.props
+    const {
+      definition,
+      currentComponent,
+      readOnly,
+      hasChange,
+      hideVersionSelector,
+      onRemove,
+      onAddComponent
+    } = this.props
     const component = EntitySpec.fromCoordinates(currentComponent)
     const isSourceComponent = this.isSourceComponent(component)
     const isDefinitionEmpty = Definition.isDefinitionEmpty(definition)
@@ -66,7 +74,7 @@ export default class ComponentButtons extends Component {
     return (
       <div className="list-activity-area">
         <ButtonGroup>
-          {!isSourceComponent && !readOnly && !isSourceEmpty && (
+          {onAddComponent && !isSourceComponent && !readOnly && !isSourceEmpty && (
             <ButtonWithTooltip
               name="addSourceComponent"
               tip={'Add the definition for source that matches this package'}
@@ -133,7 +141,7 @@ export default class ComponentButtons extends Component {
             </ButtonWithTooltip>
           )}
         </ButtonGroup>
-        {!readOnly && (
+        {onRemove && !readOnly && (
           <Button bsStyle="link" onClick={this.removeComponent.bind(this, component)}>
             <i className="fas fa-times list-remove" />
           </Button>

--- a/src/components/Navigation/Ui/__tests__/ComponentButtons.test.js
+++ b/src/components/Navigation/Ui/__tests__/ComponentButtons.test.js
@@ -54,7 +54,23 @@ describe('ComponentButtons', () => {
       />
     )
   })
+
   it('renders all the buttons', async () => {
+    const wrapper = mount(
+      <ComponentButtons
+        definition={mockedDefinition}
+        currentComponent={mockedComponent}
+        readOnly={false}
+        hasChange={() => null}
+        onAddComponent={() => null}
+        onRemove={() => null}
+      />
+    )
+    expect(wrapper.find(ButtonGroup))
+    expect(wrapper.find(Button).length).toBe(6)
+  })
+
+  it('renders some of the buttons', async () => {
     const wrapper = mount(
       <ComponentButtons
         definition={mockedDefinition}
@@ -64,8 +80,9 @@ describe('ComponentButtons', () => {
       />
     )
     expect(wrapper.find(ButtonGroup))
-    expect(wrapper.find(Button).length).toBe(6)
+    expect(wrapper.find(Button).length).toBe(4)
   })
+
   it('check functionality of each button', async () => {
     const wrapper = mount(
       <ComponentButtons


### PR DESCRIPTION
Browse page is looking good. Just a couple tweaks

* pull the Curate, Provider and Name inputs to be separate from the list to set a stronger context for the users. Still not fully happy with this. would like to strengthen the Curate messaging so it is clear to users that they can use that to find particular types of things to curate
* removed redundant entry buttons (X and </>) as they cannot be used in the context of the Browse page (system managed list)

![image](https://user-images.githubusercontent.com/10070956/54010804-1ac19380-4125-11e9-9e53-b48ae58af207.png)
