### PR TITLE
add "effective" score to Curate button

### DIFF
--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -170,6 +170,7 @@ class PageBrowse extends SystemManagedList {
     }
     if (query.curate === 'licensed') query.maxLicensedScore = 70
     if (query.curate === 'described') query.maxDescribedScore = 70
+    if (query.curate === 'effective') query.maxEffectiveScore = 70
     if (query.curate) delete query.curate
     if (activeName) {
       if (activeName.indexOf('/') > 0) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -64,7 +64,11 @@ const sources = [{ value: 'presence', label: 'Presence Of' }, { value: 'absence'
 
 const releaseDates = [{ value: 'presence', label: 'Presence Of' }, { value: 'absence', label: 'Absence Of' }]
 
-const curateFilters = [{ value: 'licensed', label: 'Licensed' }, { value: 'described', label: 'Described' }]
+const curateFilters = [
+  { value: 'effective', label: 'Focus on overall issues' },
+  { value: 'licensed', label: 'Focus on license issues' },
+  { value: 'described', label: 'Focus on description issues' }
+]
 
 const noRowsHeight = 200
 


### PR DESCRIPTION
expose the effective score as something to Curate by on the /browse page. This change is instead of #560 