### PR TITLE
fix suggestions redux caching

### DIFF
--- a/src/actions/definitionActions.js
+++ b/src/actions/definitionActions.js
@@ -95,7 +95,8 @@ export function getDefinitionSuggestedDataAction(token, prefix, name) {
     const actions = asyncActions(name)
     dispatch(actions.start())
     return getSuggestedData(token, prefix).then(
-      result => dispatch(actions.success(result)),
+      result =>
+        dispatch(actions.success({ add: { [EntitySpec.fromCoordinates(result.coordinates).toPath()]: result } })),
       error => dispatch(actions.error(error))
     )
   }

--- a/src/actions/definitionActions.js
+++ b/src/actions/definitionActions.js
@@ -16,6 +16,7 @@ import EntitySpec from '../utils/entitySpec'
 
 export const DEFINITION_LIST = 'DEFINITION_LIST'
 export const DEFINITION_BODIES = 'DEFINITION_BODIES'
+export const DEFINITION_SUGGESTIONS = 'DEFINITION_SUGGESTIONS'
 
 export function getDefinitionAction(token, entity, name) {
   return dispatch => {
@@ -89,10 +90,10 @@ export function revertAction(definition, values, name) {
   }
 }
 
-export function getDefinitionSuggestedDataAction(token, prefix, name) {
+export function getDefinitionSuggestedDataAction(token, prefix) {
   return dispatch => {
     if (!prefix) return null
-    const actions = asyncActions(name)
+    const actions = asyncActions(DEFINITION_SUGGESTIONS)
     dispatch(actions.start())
     return getSuggestedData(token, prefix).then(
       result =>

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -8,7 +8,6 @@ import {
   getDefinitionSuggestionsAction,
   resetPreviewDefinitionAction,
   revertAction,
-  getDefinitionSuggestedDataAction,
   browseDefinitionsAction
 } from './definitionActions'
 import { getHarvestOutputAction } from './harvestActions'
@@ -24,7 +23,6 @@ export const UI_INSPECT_UPDATE_FILTER = 'UI_INSPECT_UPDATE_FILTER'
 export const UI_INSPECT_GET_CURATIONS = 'UI_INSPECT_GET_CURATIONS'
 export const UI_INSPECT_GET_DEFINITION = 'UI_INSPECT_GET_DEFINITION'
 export const UI_INSPECT_GET_HARVESTED = 'UI_INSPECT_GET_HARVESTED'
-export const UI_INSPECT_GET_SUGGESTIONS = 'UI_INSPECT_GET_SUGGESTIONS'
 
 export const UI_GET_CURATION_DATA = 'UI_GET_CURATION_DATA'
 export const UI_GET_CURATIONS_LIST = 'UI_GET_CURATIONS_LIST'
@@ -176,8 +174,4 @@ export function uiHarvestUpdateFilter(value) {
 
 export function uiHarvestUpdateQueue(value) {
   return { type: UI_HARVEST_UPDATE_QUEUE, result: value }
-}
-
-export function uiInspectGetSuggestions(token, entity) {
-  return getDefinitionSuggestedDataAction(token, entity, UI_INSPECT_GET_SUGGESTIONS)
 }

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -218,6 +218,7 @@ export default class DefinitionEntry extends React.Component {
               {this.renderWithToolTipIfDifferent(
                 'licensed.declared',
                 <LicensesRenderer
+                  definition={definition}
                   field={'licensed.declared'}
                   readOnly={readOnly}
                   initialValue={this.getOriginalValue('licensed.declared')}
@@ -235,6 +236,7 @@ export default class DefinitionEntry extends React.Component {
               {this.renderWithToolTipIfDifferent(
                 'described.sourceLocation',
                 <ModalEditor
+                  definition={definition}
                   field={'described.sourceLocation'}
                   extraClass={this.classIfDifferent('described.sourceLocation')}
                   readOnly={readOnly}

--- a/src/components/FullDetailView/FullDetailPage.js
+++ b/src/components/FullDetailView/FullDetailPage.js
@@ -19,9 +19,9 @@ import {
   uiGetCurationsList,
   uiRevert,
   uiApplyCurationSuggestion,
-  uiGetCurationData,
-  uiInspectGetSuggestions
+  uiGetCurationData
 } from '../../actions/ui'
+import { getDefinitionSuggestedDataAction } from '../../actions/definitionActions'
 import { curateAction } from '../../actions/curationActions'
 import { login } from '../../actions/sessionActions'
 import Contribution from '../../utils/contribution'
@@ -86,13 +86,13 @@ export class FullDetailPage extends AbstractFullDetailsView {
       uiInspectGetDefinition,
       uiInspectGetCurations,
       uiInspectGetHarvested,
-      uiInspectGetSuggestions
+      getDefinitionSuggestedDataAction
     } = this.props
     if (!component) return
     uiInspectGetDefinition(token, component)
     uiInspectGetCurations(token, component)
     uiInspectGetHarvested(token, component)
-    uiInspectGetSuggestions(token, component)
+    getDefinitionSuggestedDataAction(token, component)
     //uiGetCurationsList(token, component)
     this.previewDefinition(component)
   }
@@ -290,7 +290,7 @@ function mapDispatchToProps(dispatch) {
       uiRevert,
       uiApplyCurationSuggestion,
       uiGetCurationData,
-      uiInspectGetSuggestions
+      getDefinitionSuggestedDataAction
     },
     dispatch
   )

--- a/src/components/LicensesRenderer.js
+++ b/src/components/LicensesRenderer.js
@@ -34,12 +34,24 @@ class LicensesRenderer extends Component {
   }
 
   render() {
-    const { extraClass, field, initialValue, onChange, onRevert, onSave, readOnly, revertable, value } = this.props
+    const {
+      extraClass,
+      field,
+      initialValue,
+      onChange,
+      onRevert,
+      onSave,
+      readOnly,
+      revertable,
+      value,
+      definition
+    } = this.props
     const { advancedView } = this.state
 
     return (
       <div className="license-renderer">
         <InlineEditor
+          definition={definition}
           field={field}
           extraClass={extraClass}
           readOnly={readOnly}
@@ -67,10 +79,8 @@ class LicensesRenderer extends Component {
 }
 
 LicensesRenderer.propTypes = {
-  /**
-   * item to show
-   */
-  value: PropTypes.string.isRequired,
+  definition: PropTypes.object,
+  value: PropTypes.string,
   extraClass: PropTypes.string,
   onSave: PropTypes.func,
   readOnly: PropTypes.bool,

--- a/src/components/Navigation/Ui/EditableFieldRenderer.js
+++ b/src/components/Navigation/Ui/EditableFieldRenderer.js
@@ -87,6 +87,7 @@ class EditableFieldRenderer extends Component {
     const renderEditor = () =>
       editor ? (
         <ModalEditor
+          definition={definition}
           field={field}
           extraClass={Contribution.classIfDifferent(definition, previewDefinition, field)}
           readOnly={readOnly}
@@ -103,6 +104,7 @@ class EditableFieldRenderer extends Component {
         />
       ) : (
         <InlineEditor
+          definition={definition}
           field={field}
           extraClass={Contribution.classIfDifferent(definition, previewDefinition, field)}
           readOnly={readOnly}

--- a/src/components/SourcePicker.js
+++ b/src/components/SourcePicker.js
@@ -72,15 +72,14 @@ class SourcePicker extends Component {
           <Col md={2}>{this.renderProviderButtons()}</Col>
           <Col md={5}>{activeProvider === 'github' && <GitHubSelector onChange={this.onSelectComponent} />}</Col>
           <Col md={5}>
-            {selectedComponent &&
-              activeProvider === 'github' && (
-                <GitHubCommitPicker
-                  allowNew
-                  request={selectedComponent}
-                  getGitHubRevisions={path => getGitHubRevisions(this.props.token, path)}
-                  onChange={this.commitChanged.bind(this, selectedComponent)}
-                />
-              )}
+            {selectedComponent && activeProvider === 'github' && (
+              <GitHubCommitPicker
+                allowNew
+                request={selectedComponent}
+                getGitHubRevisions={path => getGitHubRevisions(this.props.token, path)}
+                onChange={this.commitChanged.bind(this, selectedComponent)}
+              />
+            )}
           </Col>
         </Row>
         <Row className="spacer">

--- a/src/components/__tests__/InlineEditor.test.js
+++ b/src/components/__tests__/InlineEditor.test.js
@@ -14,13 +14,13 @@ describe('InlineEditor', () => {
           filter: {},
           filterList: {},
           componentList: {}
-        },
-        inspect: {
-          suggestedData: {}
         }
       },
       definition: {
         bodies: {}
+      },
+      suggestion: {
+        suggestions: {}
       }
     })
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,12 +5,14 @@ import { combineReducers } from 'redux'
 import sessionReducer from './sessionReducer'
 import uiReducer from './uiReducer'
 import definitionReducer from './definitionReducer'
+import suggestionReducer from './suggestionReducer'
 // import harvestReducer from './harvestReducer'
 
 const rootReducer = combineReducers({
   session: sessionReducer,
   ui: uiReducer,
-  definition: definitionReducer
+  definition: definitionReducer,
+  suggestion: suggestionReducer
   // harvest: harvestReducer
 })
 

--- a/src/reducers/suggestionReducer.js
+++ b/src/reducers/suggestionReducer.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { combineReducers } from 'redux'
-import { UI_INSPECT_GET_SUGGESTIONS } from '../actions/ui'
+import { DEFINITION_SUGGESTIONS } from '../actions/definitionActions'
 import tableReducer from './tableReducer'
 
 export default combineReducers({
-  suggestions: tableReducer(UI_INSPECT_GET_SUGGESTIONS)
+  bodies: tableReducer(DEFINITION_SUGGESTIONS)
 })

--- a/src/reducers/suggestionReducer.js
+++ b/src/reducers/suggestionReducer.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import { combineReducers } from 'redux'
+import { UI_INSPECT_GET_SUGGESTIONS } from '../actions/ui'
+import tableReducer from './tableReducer'
+
+export default combineReducers({
+  suggestions: tableReducer(UI_INSPECT_GET_SUGGESTIONS)
+})

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -104,7 +104,6 @@ const inspect = combineReducers({
   definition: itemReducer(UI_INSPECT_GET_DEFINITION, item => yaml.safeDump(item, { sortKeys: true })),
   curations: itemReducer(UI_INSPECT_GET_CURATIONS, item => yaml.safeDump(item, { sortKeys: true })),
   harvested: itemReducer(UI_INSPECT_GET_HARVESTED, item => JSON.stringify(item, null, 2)),
-  suggestedData: itemReducer(UI_INSPECT_GET_SUGGESTIONS, item => yaml.safeDump(item, { sortKeys: true })),
   curationList: itemReducer(UI_GET_CURATIONS_LIST, item => yaml.safeDump(item, { sortKeys: true })),
   inspectedCuration: itemReducer(UI_GET_CURATION_DATA, item => yaml.safeDump(item, { sortKeys: true }))
 })

--- a/src/reducers/uiReducer.js
+++ b/src/reducers/uiReducer.js
@@ -30,8 +30,7 @@ import {
   UI_INSPECT_GET_DEFINITION,
   UI_INSPECT_GET_HARVESTED,
   UI_GET_CURATIONS_LIST,
-  UI_GET_CURATION_DATA,
-  UI_INSPECT_GET_SUGGESTIONS
+  UI_GET_CURATION_DATA
 } from '../actions/ui'
 import listReducer from './listReducer'
 import tableReducer from './tableReducer'

--- a/src/utils/withSuggestions.js
+++ b/src/utils/withSuggestions.js
@@ -39,7 +39,7 @@ function withSuggestions(WrappedComponent) {
 function mapStateToProps(state, props) {
   if (!props.definition) return {}
   const coordinates = EntitySpec.fromCoordinates(props.definition.coordinates).toPath()
-  const suggestion = get(state.suggestion.suggestions.entries, coordinates)
+  const suggestion = get(state.suggestion.bodies.entries, coordinates)
   return {
     suggestedData: suggestion && get(suggestion, props.field)
   }

--- a/src/utils/withSuggestions.js
+++ b/src/utils/withSuggestions.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import get from 'lodash/get'
 import SuggestionsList from '../components/Navigation/Ui/Suggestions/SuggestionsList'
+import EntitySpec from './entitySpec'
 
 /**
  * HoC that manage the suggestion functionality for a Component
@@ -36,8 +37,11 @@ function withSuggestions(WrappedComponent) {
 }
 
 function mapStateToProps(state, props) {
+  if (!props.definition) return {}
+  const coordinates = EntitySpec.fromCoordinates(props.definition.coordinates).toPath()
+  const suggestion = get(state.suggestion.suggestions.entries, coordinates)
   return {
-    suggestedData: get(state.ui.inspect.suggestedData.item, props.field)
+    suggestedData: suggestion && get(suggestion, props.field)
   }
 }
 


### PR DESCRIPTION
`withSuggestions` was storing/getting the suggestion to show in/from one place. that meant that everywhere in the ui that showed a suggestions was showing the same suggestion. Even on different components. This change makes the suggestion redux store a table and puts all the suggestions in there keyed by coordinates. Now once a suggestion is loaded it is available to the correct component anywhere in the UI.