### PR TITLE
update score renderer to use effective score

### DIFF
--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -100,7 +100,7 @@ class ScoreRenderer extends Component {
       <Tooltip title={this.renderTooltipContent} key={this.renderTooltipContent} overlayStyle={{ width: '800px' }}>
         {domain ? (
           <Tag className="cd-badge" color={this.getColor(get(domain, 'score.total'))}>
-            {get(domain, 'toolScore.total')}
+            {get(domain, 'score.total')}
           </Tag>
         ) : (
           <Tag className="cd-badge" color={this.getColor(scores.effective)}>


### PR DESCRIPTION
I noticed this because it was rendering 0 on the badge for a curated component

![image](https://user-images.githubusercontent.com/5168796/54150169-0ca99680-43f5-11e9-9d00-2a59f35a55ea.png)

update to show the effective score

![image](https://user-images.githubusercontent.com/5168796/54150219-29de6500-43f5-11e9-881f-cfb2e090f278.png)
