### PR TITLE
Missing component-name in E2E

### DIFF
--- a/e2e/maps/definitions.js
+++ b/e2e/maps/definitions.js
@@ -15,7 +15,7 @@ export const definitionsMap = {
     revertButton: '[data-test-id="notification-revert-confirm"]'
   },
   component: {
-    name: '[data-test-id="component-name"]',
+    name: '.list-headline [data-test-id="component-name"]',
     image: '.list-image',
     buttons: '.list-activity-area',
     sourceButton: '.list-fa-button > i.fa-code',
@@ -64,7 +64,7 @@ export const definitionsMap = {
   licensePicker: {
     identifier: '.spdx-picker',
     inputField:
-      '[data-test-id="spdx-input-picker"] > div.rbt > div.rbt-input.form-control > .rbt-input-wrapper > div > .rbt-input-main',
+      '.spdx-picker [data-test-id="spdx-input-picker"] > div.rbt > div.rbt-input.form-control > .rbt-input-wrapper > div > .rbt-input-main',
     listSelection: '#rbt-menu-item-1',
     buttonSuccess: '[data-test-id="license-picker-ok-button"]'
   },

--- a/e2e/tests/definitions.js
+++ b/e2e/tests/definitions.js
@@ -44,6 +44,7 @@ describe(
         `${definitionsMap.componentList.list} ${definitionsMap.componentList.firstElement}`
       )
       const componentTitle = await page.$(definitionsMap.component.name)
+      await expect(componentTitle).not.toBeNull()
       const text = await (await componentTitle.getProperty('textContent')).jsonValue()
       await expect(text).toMatch('async')
       await page.waitForSelector(definitionsMap.component.image)

--- a/src/components/DefinitionEntry.js
+++ b/src/components/DefinitionEntry.js
@@ -74,19 +74,14 @@ export default class DefinitionEntry extends React.Component {
     const scores = Definition.computeScores(definition)
     const isCurationPending = Curation.isPending(curation)
     const componentTag = get(definition, 'described.urls.registry') ? (
-      <span>
-        <a
-          href={get(definition, 'described.urls.registry')}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-test-id="component-name"
-        >
+      <span data-test-id="component-name">
+        <a href={get(definition, 'described.urls.registry')} target="_blank" rel="noopener noreferrer">
           {namespaceText}
           {name}
         </a>
       </span>
     ) : (
-      <span>
+      <span data-test-id="component-name">
         {namespaceText}
         {name}
       </span>


### PR DESCRIPTION
This one fixes some problems that recently caused failures with E2E during the CI