### PR TITLE
Fix Provider icon title in Harvest Page

### DIFF
--- a/src/components/HarvestQueueList.js
+++ b/src/components/HarvestQueueList.js
@@ -151,6 +151,7 @@ class HarvestQueueList extends React.Component {
     return (
       <div key={key} style={style}>
         <TwoLineEntry
+          item={request}
           image={this.getImage(request)}
           letter={this.getLetter(request)}
           headline={this.renderHeadline(request)}

--- a/src/components/TwoLineEntry.js
+++ b/src/components/TwoLineEntry.js
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import get from 'lodash/get'
 export default class TwoLineEntry extends React.Component {
   static propTypes = {
     buttons: PropTypes.element,
@@ -35,6 +35,8 @@ export default class TwoLineEntry extends React.Component {
       draggable,
       item
     } = this.props
+
+    console.log(item)
     return (
       <div
         className="two-line-entry"
@@ -48,12 +50,12 @@ export default class TwoLineEntry extends React.Component {
             <img
               className={`list-image${highlight ? ' list-highlight' : ''}`}
               src={image}
-              alt={item.provider}
-              title={item.provider}
+              alt={get(item, 'provider')}
+              title={get(item, 'provider')}
             />
           )}
           {letter && !image && (
-            <span className={`list-letter${highlight ? ' list-highlight' : ''}`} title={item.provider}>
+            <span className={`list-letter${highlight ? ' list-highlight' : ''}`} title={get(item, 'provider')}>
               {letter.slice(0, 1)}
             </span>
           )}

--- a/src/components/TwoLineEntry.js
+++ b/src/components/TwoLineEntry.js
@@ -3,7 +3,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import get from 'lodash/get'
+
 export default class TwoLineEntry extends React.Component {
   static propTypes = {
     buttons: PropTypes.element,
@@ -35,8 +35,6 @@ export default class TwoLineEntry extends React.Component {
       draggable,
       item
     } = this.props
-
-    console.log(item)
     return (
       <div
         className="two-line-entry"
@@ -50,12 +48,12 @@ export default class TwoLineEntry extends React.Component {
             <img
               className={`list-image${highlight ? ' list-highlight' : ''}`}
               src={image}
-              alt={get(item, 'provider')}
-              title={get(item, 'provider')}
+              alt={item.provider}
+              title={item.provider}
             />
           )}
           {letter && !image && (
-            <span className={`list-letter${highlight ? ' list-highlight' : ''}`} title={get(item, 'provider')}>
+            <span className={`list-letter${highlight ? ' list-highlight' : ''}`} title={item.provider}>
               {letter.slice(0, 1)}
             </span>
           )}


### PR DESCRIPTION
I've noticed that the previous fix in #597  crashed in the Harvest page since in that page the TwoLineEntry component doesn't receive the full item details.

This PR fix that wrong behavior.