### PR TITLE
Moved buildSaveSpec to SystemManagedList

### DIFF
--- a/src/components/SystemManagedList.js
+++ b/src/components/SystemManagedList.js
@@ -336,4 +336,8 @@ export default class SystemManagedList extends Component {
   }
 
   updateList() {}
+
+  buildSaveSpec(list) {
+    return list.map(component => EntitySpec.fromObject(component))
+  }
 }

--- a/src/components/UserManagedList.js
+++ b/src/components/UserManagedList.js
@@ -167,10 +167,6 @@ export default class UserManagedList extends SystemManagedList {
     )
   }
 
-  buildSaveSpec(list) {
-    return list.map(component => EntitySpec.fromObject(component))
-  }
-
   async doSave() {
     const { components } = this.props
     const spec = this.buildSaveSpec(components.list)


### PR DESCRIPTION
As noticed in #618 and #614 , the `buildSaveSpec` method needed to be moved to the `SystemManagedList` , since the new home page, which is actually a `SystemManagedList`, is implementing some methods that previously was used only in the `UserManagedList`, like the method above.

Fixes #618 
Fixes #614 