### PR TITLE
Show Tools and Attributions tooltip/overlay on hover

### DIFF
--- a/src/components/Navigation/Ui/ListDataRenderer.js
+++ b/src/components/Navigation/Ui/ListDataRenderer.js
@@ -10,16 +10,21 @@ export default class ListDataRenderer extends Component {
     licensed: PropTypes.object,
     item: PropTypes.string,
     title: PropTypes.string,
+    trigger: PropTypes.string,
     values: PropTypes.array
   }
 
+  static defaultProps = {
+    trigger: 'hover'
+  }
+
   render() {
-    const { licensed, item, values, title } = this.props
+    const { licensed, item, values, title, trigger } = this.props
     const data = values || get(licensed, item, [])
     if (!data) return null
     return (
       <OverlayTrigger
-        trigger="click"
+        trigger={trigger}
         placement="left"
         rootClose
         overlay={


### PR DESCRIPTION
With #596 in place, we noticed that the tooltip shows up only when clicking the Tools or Attributions field, which is not a clear behavior.

We've updated the implementation allow the tooltip to show when hovering the fields.