### PR TITLE
Stats page updates

### DIFF
--- a/src/actions/statsActions.js
+++ b/src/actions/statsActions.js
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import { asyncActions } from './'
+import { getStats } from '../api/clearlyDefined'
+
+export const STATS_GET = 'STATS_GET'
+
+export function getStatAction(type) {
+  return dispatch => {
+    const actions = asyncActions(STATS_GET)
+    dispatch(actions.start())
+    return getStats(type).then(
+      result => dispatch(actions.success({ add: { [type]: result } })),
+      error => dispatch(actions.error(error))
+    )
+  }
+}

--- a/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
+++ b/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
@@ -3,37 +3,27 @@
 
 import React, { Component } from 'react'
 import { Row, Col } from 'react-bootstrap'
-import { getStats } from '../../../../api/clearlyDefined'
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { primaryColor, secondaryColor, describedColor, secureColor } from '../../../Clearly'
 const colors = [primaryColor.color, secondaryColor.color, describedColor.color, secureColor.color]
 
 export default class LicenseBreakdown extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
+  static defaultProps = {
+    stats: {
+      totalCount: 0,
       declaredLicenseBreakdown: []
     }
   }
 
-  async componentDidMount() {
-    const data = await getStats(this.props.type)
-    if (!data.value) return
-    this.setState({
-      totalCount: data.value.totalCount,
-      declaredLicenseBreakdown: data.value.declaredLicenseBreakdown
-    })
-  }
-
   render() {
-    const { declaredLicenseBreakdown, totalCount } = this.state
+    const { stats } = this.props
 
     return (
       <Row>
         <Col md={6}>
           <table style={{ margin: '60px' }}>
             <tbody>
-              {declaredLicenseBreakdown.map((entry, index) => {
+              {stats.declaredLicenseBreakdown.map((entry, index) => {
                 return (
                   <tr key={index}>
                     <td>
@@ -51,7 +41,7 @@ export default class LicenseBreakdown extends Component {
                       <h4>{entry.value}</h4>
                     </td>
                     <td>
-                      <h4>{((entry.count * 100) / totalCount).toFixed(2)}%</h4>
+                      <h4>{((entry.count * 100) / stats.totalCount).toFixed(2)}%</h4>
                     </td>
                   </tr>
                 )
@@ -64,7 +54,7 @@ export default class LicenseBreakdown extends Component {
             <BarChart
               width={900}
               height={260}
-              data={declaredLicenseBreakdown}
+              data={stats.declaredLicenseBreakdown}
               margin={{ top: 5, right: 0, left: 0, bottom: 25 }}
             >
               <XAxis dataKey="value" tickSize dy="25" />
@@ -72,7 +62,7 @@ export default class LicenseBreakdown extends Component {
               <Tooltip />
               <CartesianGrid vertical={false} stroke="#ebf3f0" />
               <Bar dataKey="count" barSize={170}>
-                {declaredLicenseBreakdown.map((entry, index) => (
+                {stats.declaredLicenseBreakdown.map((entry, index) => (
                   <Cell fill={colors[index % colors.length]} />
                 ))}
               </Bar>

--- a/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
+++ b/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import React, { Component } from 'react'
+import { Row, Col } from 'react-bootstrap'
+import { getStats } from '../../../../api/clearlyDefined'
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { primaryColor, secondaryColor, describedColor, secureColor } from '../../../Clearly'
+const colors = [primaryColor.color, secondaryColor.color, describedColor.color, secureColor.color]
+
+export default class LicenseBreakdown extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      declaredLicenseBreakdown: []
+    }
+  }
+
+  async componentDidMount() {
+    const data = await getStats(this.props.type)
+    if (!data.value) return
+    this.setState({
+      totalCount: data.value.totalCount,
+      declaredLicenseBreakdown: data.value.declaredLicenseBreakdown
+    })
+  }
+
+  render() {
+    const { declaredLicenseBreakdown, totalCount } = this.state
+
+    return (
+      <Row>
+        <Col md={6}>
+          <table style={{ margin: '60px' }}>
+            <tbody>
+              {declaredLicenseBreakdown.map((entry, index) => {
+                return (
+                  <tr key={index}>
+                    <td>
+                      <span
+                        style={{
+                          backgroundColor: colors[index % colors.length],
+                          height: '20px',
+                          width: '20px',
+                          marginRight: '10px',
+                          display: 'inline-block'
+                        }}
+                      />
+                    </td>
+                    <td width="250">
+                      <h4>{entry.value}</h4>
+                    </td>
+                    <td>
+                      <h4>{((entry.count * 100) / totalCount).toFixed(2)}%</h4>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </Col>
+        <Col md={6}>
+          <ResponsiveContainer height={500}>
+            <BarChart
+              width={900}
+              height={260}
+              data={declaredLicenseBreakdown}
+              margin={{ top: 5, right: 0, left: 0, bottom: 25 }}
+            >
+              <XAxis dataKey="value" tickSize dy="25" />
+              <YAxis hide />
+              <Tooltip />
+              <CartesianGrid vertical={false} stroke="#ebf3f0" />
+              <Bar dataKey="count" barSize={170}>
+                {declaredLicenseBreakdown.map((entry, index) => (
+                  <Cell fill={colors[index % colors.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </Col>
+      </Row>
+    )
+  }
+}

--- a/src/components/Navigation/Pages/PageStats/PageStats.js
+++ b/src/components/Navigation/Pages/PageStats/PageStats.js
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
-import { Grid, Row, Jumbotron } from 'react-bootstrap'
+import { Grid, Row, Jumbotron, Tabs, Tab } from 'react-bootstrap'
 import TypeCard from './TypeCard'
+import LicenseBreakdown from './LicenseBreakdown'
 import CountUp from 'react-countup'
 import { getStats } from '../../../../api/clearlyDefined'
 import npm from '../../../../../src/images/n-large.png'
@@ -24,8 +25,12 @@ export default class PageStats extends Component {
   }
 
   async componentDidMount() {
-    const totalComponents = await getStats('totalcount')
-    this.setState({ totalComponents: totalComponents.value })
+    const stats = await getStats('total')
+    this.setState({
+      totalComponents: stats.value.totalCount,
+      describedScoreMedian: stats.value.describedScoreMedian,
+      licensedScoreMedian: stats.value.licensedScoreMedian
+    })
   }
 
   render() {
@@ -37,19 +42,52 @@ export default class PageStats extends Component {
               <CountUp end={this.state.totalComponents} separator="," />
             </h2>
             <p>Number of total definitions</p>
+            <small>median licensed score: {this.state.licensedScoreMedian}</small>
+            <small> | </small>
+            <small>median described score: {this.state.describedScoreMedian}</small>
           </Jumbotron>
         </Row>
         <Row>
           <div className="card-container">
             <TypeCard type="npm" image={npm} />
+            <TypeCard type="gem" image={gem} />
+            <TypeCard type="pypi" image={pypi} />
             <TypeCard type="maven" image={maven} />
             <TypeCard type="nuget" image={nuget} />
             <TypeCard type="git" image={git} />
             <TypeCard type="pod" image={pod} />
             <TypeCard type="crate" image={crate} />
-            <TypeCard type="gem" image={gem} />
-            <TypeCard type="pypi" image={pypi} />
           </div>
+        </Row>
+        <hr />
+        <Row>
+          <h2>Declared License Breakdown</h2>
+          <Tabs>
+            <Tab eventKey="overall" title="Overall">
+              <LicenseBreakdown type="total" />
+            </Tab>
+            <Tab eventKey="npm" title="NPM">
+              <LicenseBreakdown type="npm" />
+            </Tab>
+            <Tab eventKey="gem" title="Gem">
+              <LicenseBreakdown type="gem" />
+            </Tab>
+            <Tab eventKey="pypi" title="PyPi">
+              <LicenseBreakdown type="pypi" />
+            </Tab>
+            <Tab eventKey="maven" title="Maven">
+              <LicenseBreakdown type="maven" />
+            </Tab>
+            <Tab eventKey="nuget" title="NuGet">
+              <LicenseBreakdown type="nuget" />
+            </Tab>
+            <Tab eventKey="git" title="Git">
+              <LicenseBreakdown type="git" />
+            </Tab>
+            <Tab eventKey="pod" title="Pod">
+              <LicenseBreakdown type="pod" />
+            </Tab>
+          </Tabs>
         </Row>
       </Grid>
     )

--- a/src/components/Navigation/Pages/PageStats/PageStats.js
+++ b/src/components/Navigation/Pages/PageStats/PageStats.js
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import { Grid, Row, Jumbotron, Tabs, Tab } from 'react-bootstrap'
+import { getStatAction } from '../../../../actions/statsActions'
+import get from 'lodash/get'
 import TypeCard from './TypeCard'
 import LicenseBreakdown from './LicenseBreakdown'
 import CountUp from 'react-countup'
-import { getStats } from '../../../../api/clearlyDefined'
 import npm from '../../../../../src/images/n-large.png'
 import maven from '../../../../../src/images/maven.png'
 import nuget from '../../../../../src/images/nuget.svg'
@@ -16,47 +18,50 @@ import crate from '../../../../../src/images/cargo.png'
 import gem from '../../../../../src/images/gem.png'
 import pypi from '../../../../../src/images/pypi.png'
 
-export default class PageStats extends Component {
+const types = {
+  npm: npm,
+  gem: gem,
+  pypi: pypi,
+  maven: maven,
+  nuget: nuget,
+  git: git,
+  crate: crate,
+  pod: pod
+}
+
+class PageStats extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      totalComponents: 0
-    }
+    this.state = {}
   }
 
   async componentDidMount() {
-    const stats = await getStats('total')
-    this.setState({
-      totalComponents: stats.value.totalCount,
-      describedScoreMedian: stats.value.describedScoreMedian,
-      licensedScoreMedian: stats.value.licensedScoreMedian
-    })
+    await Promise.all([
+      this.props.dispatch(getStatAction('total')),
+      ...Object.keys(types).map(type => this.props.dispatch(getStatAction(type)))
+    ])
   }
 
   render() {
+    const { stats } = this.props
     return (
       <Grid className="main-container">
         <Row>
           <Jumbotron className="text-center" style={{ backgroundColor: '#ecf0f1' }}>
             <h2>
-              <CountUp end={this.state.totalComponents} separator="," />
+              <CountUp end={get(stats, 'entries.total.value.totalCount') || 0} separator="," />
             </h2>
             <p>Number of total definitions</p>
-            <small>median licensed score: {this.state.licensedScoreMedian}</small>
+            <small>median licensed score: {get(stats, 'entries.total.value.licensedScoreMedian') || 0}</small>
             <small> | </small>
-            <small>median described score: {this.state.describedScoreMedian}</small>
+            <small>median described score: {get(stats, 'entries.total.value.describedScoreMedian') || 0}</small>
           </Jumbotron>
         </Row>
         <Row>
           <div className="card-container">
-            <TypeCard type="npm" image={npm} />
-            <TypeCard type="gem" image={gem} />
-            <TypeCard type="pypi" image={pypi} />
-            <TypeCard type="maven" image={maven} />
-            <TypeCard type="nuget" image={nuget} />
-            <TypeCard type="git" image={git} />
-            <TypeCard type="pod" image={pod} />
-            <TypeCard type="crate" image={crate} />
+            {Object.keys(types).map(type => (
+              <TypeCard type={type} image={types[type]} stats={get(stats, `entries.${type}.value`)} />
+            ))}
           </div>
         </Row>
         <hr />
@@ -64,32 +69,24 @@ export default class PageStats extends Component {
           <h2>Declared License Breakdown</h2>
           <Tabs>
             <Tab eventKey="overall" title="Overall">
-              <LicenseBreakdown type="total" />
+              <LicenseBreakdown type="total" stats={get(stats, 'entries.total.value')} />
             </Tab>
-            <Tab eventKey="npm" title="NPM">
-              <LicenseBreakdown type="npm" />
-            </Tab>
-            <Tab eventKey="gem" title="Gem">
-              <LicenseBreakdown type="gem" />
-            </Tab>
-            <Tab eventKey="pypi" title="PyPi">
-              <LicenseBreakdown type="pypi" />
-            </Tab>
-            <Tab eventKey="maven" title="Maven">
-              <LicenseBreakdown type="maven" />
-            </Tab>
-            <Tab eventKey="nuget" title="NuGet">
-              <LicenseBreakdown type="nuget" />
-            </Tab>
-            <Tab eventKey="git" title="Git">
-              <LicenseBreakdown type="git" />
-            </Tab>
-            <Tab eventKey="pod" title="Pod">
-              <LicenseBreakdown type="pod" />
-            </Tab>
+            {Object.keys(types).map(type => (
+              <Tab eventKey={type} title={type}>
+                <LicenseBreakdown type="total" stats={get(stats, `entries.${type}.value`)} />
+              </Tab>
+            ))}
           </Tabs>
         </Row>
       </Grid>
     )
   }
 }
+
+function mapStateToProps(state) {
+  return {
+    stats: state.stat.bodies
+  }
+}
+
+export default connect(mapStateToProps)(PageStats)

--- a/src/components/Navigation/Pages/PageStats/TypeCard.js
+++ b/src/components/Navigation/Pages/PageStats/TypeCard.js
@@ -6,40 +6,30 @@ import { UserCard } from 'react-ui-cards'
 import { getStats } from '../../../../api/clearlyDefined'
 
 export default class TypeCard extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
+  static defaultProps = {
+    stats: {
       totalCount: 0,
       describedScoreMedian: 0,
       licensedScoreMedian: 0
     }
   }
 
-  async componentDidMount() {
-    const data = await getStats(this.props.type)
-    if (!data.value) return
-    this.setState({
-      totalCount: data.value.totalCount,
-      describedScoreMedian: data.value.describedScoreMedian,
-      licensedScoreMedian: data.value.licensedScoreMedian
-    })
-  }
-
   render() {
+    const { image, type, stats } = this.props
     return (
       <UserCard
         cardClass="float"
-        header={this.props.image}
-        name={this.props.type}
-        positionName={`total count: ${this.state.totalCount.toLocaleString()}`}
+        header={image}
+        name={type}
+        positionName={`total count: ${stats.totalCount.toLocaleString()}`}
         stats={[
           {
             name: 'median licensed score',
-            value: this.state.licensedScoreMedian
+            value: stats.licensedScoreMedian
           },
           {
             name: 'median described score',
-            value: this.state.describedScoreMedian
+            value: stats.describedScoreMedian
           }
         ]}
       />

--- a/src/components/Navigation/Pages/PageStats/TypeCard.js
+++ b/src/components/Navigation/Pages/PageStats/TypeCard.js
@@ -7,8 +7,8 @@ export default class TypeCard extends Component {
     super(props)
     this.state = {
       totalCount: 0,
-      averageLicensed: 0,
-      averageDescribed: 0
+      describedScoreMedian: 0,
+      licensedScoreMedian: 0
     }
   }
 
@@ -16,9 +16,9 @@ export default class TypeCard extends Component {
     const data = await getStats(this.props.type)
     if (!data.value) return
     this.setState({
-      totalCount: data.value.totalcount,
-      averageLicensed: Math.round(data.value['avg_licensed.score.total'] * 100) / 100,
-      averageDescribed: Math.round(data.value['avg_described.score.total'] * 100) / 100
+      totalCount: data.value.totalCount,
+      describedScoreMedian: data.value.describedScoreMedian,
+      licensedScoreMedian: data.value.licensedScoreMedian
     })
   }
 
@@ -28,15 +28,15 @@ export default class TypeCard extends Component {
         cardClass="float"
         header={this.props.image}
         name={this.props.type}
-        positionName={`total count: ${this.state.totalCount}`}
+        positionName={`total count: ${this.state.totalCount.toLocaleString()}`}
         stats={[
           {
-            name: 'average licensed score',
-            value: this.state.averageLicensed
+            name: 'median licensed score',
+            value: this.state.licensedScoreMedian
           },
           {
-            name: 'average described score',
-            value: this.state.averageDescribed
+            name: 'median described score',
+            value: this.state.describedScoreMedian
           }
         ]}
       />

--- a/src/components/Navigation/Pages/PageStats/TypeCard.js
+++ b/src/components/Navigation/Pages/PageStats/TypeCard.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
 import React, { Component } from 'react'
 import { UserCard } from 'react-ui-cards'
 import { getStats } from '../../../../api/clearlyDefined'

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,13 +6,15 @@ import sessionReducer from './sessionReducer'
 import uiReducer from './uiReducer'
 import definitionReducer from './definitionReducer'
 import suggestionReducer from './suggestionReducer'
+import statReducer from './statReducer'
 // import harvestReducer from './harvestReducer'
 
 const rootReducer = combineReducers({
   session: sessionReducer,
   ui: uiReducer,
   definition: definitionReducer,
-  suggestion: suggestionReducer
+  suggestion: suggestionReducer,
+  stat: statReducer
   // harvest: harvestReducer
 })
 

--- a/src/reducers/statReducer.js
+++ b/src/reducers/statReducer.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+import { combineReducers } from 'redux'
+import { STATS_GET } from '../actions/statsActions'
+import tableReducer from './tableReducer'
+
+export default combineReducers({
+  bodies: tableReducer(STATS_GET)
+})


### PR DESCRIPTION
this gets the rest of the stats page working again with a type breakdown
switches from average scores to median scores
includes a license breakdown
![2019-04-07 17 12 31](https://user-images.githubusercontent.com/5168796/55734612-b66c4b00-59d4-11e9-833d-eb39b0adc902.gif)
