### PR TITLE
Score Rendering improvements

### DIFF
--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -49,7 +49,8 @@ class ScoreRenderer extends Component {
     const color = this.getColor(score[name], maxScores[name] || 100, ['#d6af22', '#2cbe4e'])
     return (
       <p style={{ color }}>
-        {label}: {score[name]}/100 points
+        {label}: {score[name]}
+        {this.renderUnit()}
       </p>
     )
   }
@@ -82,16 +83,28 @@ class ScoreRenderer extends Component {
     return (
       <div className="ScoreRenderer__domain">
         <div className="ScoreRenderer__domain__section">
-          <h2>{`Effective: ${isNumber(effective.total) ? effective.total : effective}`}</h2>
+          <h2>
+            {`Effective: ${isNumber(effective.total) ? effective.total : effective}`}
+            {this.renderUnit()}
+          </h2>
           {this.renderScore(effective)}
         </div>
         <div className="ScoreRenderer__domain__section">
-          <h2>{`Tools: ${isNumber(tools.total) ? tools.total : tools}`}</h2>
+          <h2>
+            {`Tools: ${isNumber(tools.total) ? tools.total : tools}`}
+            {this.renderUnit()}
+          </h2>
           {this.renderScore(tools)}
         </div>
       </div>
     )
   }
+
+  renderUnit = () => (
+    <span>
+      / 100 <span className="unit">points</span>
+    </span>
+  )
 
   render() {
     const { domain, scores } = this.props

--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -72,10 +72,15 @@ class ScoreRenderer extends Component {
 
           <h2>Licensed</h2>
           {this.renderScores(licensedScore, licensedToolScore)}
+          {this.renderScoreInfo()}
         </div>
       )
     } else {
-      return <div className="ScoreRenderer">{this.renderScores(get(domain, 'score'), get(domain, 'toolScore'))}</div>
+      return (
+        <div className="ScoreRenderer">
+          {this.renderScores(get(domain, 'score'), get(domain, 'toolScore'))} {this.renderScoreInfo()}
+        </div>
+      )
     }
   }
 
@@ -104,6 +109,17 @@ class ScoreRenderer extends Component {
     <span>
       / 100 <span className="unit">points</span>
     </span>
+  )
+
+  renderScoreInfo = () => (
+    <div className="ScoreInfo">
+      <a
+        href="https://github.com/clearlydefined/license-score/blob/master/ClearlyLicensedMetrics.md#clearlylicensed-scoring-formula"
+        target="_blank"
+      >
+        What does these scores mean?
+      </a>
+    </div>
   )
 
   render() {

--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -105,11 +105,7 @@ class ScoreRenderer extends Component {
     )
   }
 
-  renderUnit = () => (
-    <span>
-      / 100 <span className="unit">points</span>
-    </span>
-  )
+  renderUnit = () => <span>/100</span>
 
   renderScoreInfo = () => (
     <div className="ScoreInfo">
@@ -117,7 +113,7 @@ class ScoreRenderer extends Component {
         href="https://github.com/clearlydefined/license-score/blob/master/ClearlyLicensedMetrics.md#clearlylicensed-scoring-formula"
         target="_blank"
       >
-        What does these scores mean?
+        Scoring Formula
       </a>
     </div>
   )

--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -49,7 +49,7 @@ class ScoreRenderer extends Component {
     const color = this.getColor(score[name], maxScores[name] || 100, ['#d6af22', '#2cbe4e'])
     return (
       <p style={{ color }}>
-        {label}: {score[name]}
+        {label}: {score[name]}/100 points
       </p>
     )
   }

--- a/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
+++ b/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
@@ -49,19 +49,13 @@ describe('ScoreRenderer', () => {
       <div className="ScoreRenderer__domain">
         <div className="ScoreRenderer__domain__section">
           <h2>
-            Effective: 0
-            <span>
-              / 100 <span className="unit">points</span>
-            </span>
+            Effective: 0<span>/100</span>
           </h2>
           {instance.renderScore(licensedScore)}
         </div>
         <div className="ScoreRenderer__domain__section">
           <h2>
-            Tools: 0
-            <span>
-              / 100 <span className="unit">points</span>
-            </span>
+            Tools: 0<span>/100</span>
           </h2>
           {instance.renderScore(licensedToolScore)}
         </div>

--- a/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
+++ b/src/components/Navigation/Ui/__tests__/ScoreRenderer.test.js
@@ -48,11 +48,21 @@ describe('ScoreRenderer', () => {
     expect(resultScores).toEqual(
       <div className="ScoreRenderer__domain">
         <div className="ScoreRenderer__domain__section">
-          <h2>Effective: 0</h2>
+          <h2>
+            Effective: 0
+            <span>
+              / 100 <span className="unit">points</span>
+            </span>
+          </h2>
           {instance.renderScore(licensedScore)}
         </div>
         <div className="ScoreRenderer__domain__section">
-          <h2>Tools: 0</h2>
+          <h2>
+            Tools: 0
+            <span>
+              / 100 <span className="unit">points</span>
+            </span>
+          </h2>
           {instance.renderScore(licensedToolScore)}
         </div>
       </div>

--- a/src/styles/_ScoreRenderer.scss
+++ b/src/styles/_ScoreRenderer.scss
@@ -5,6 +5,15 @@
     color: white;
     font-size: 16px;
   }
+  .ScoreInfo {
+    font-size: 12px;
+    text-decoration: underline;
+    width: 100%;
+    text-align: right;
+    a {
+      color: white;
+    }
+  }
   .ScoreRenderer__domain {
     display: flex;
     width: 400px;

--- a/src/styles/_ScoreRenderer.scss
+++ b/src/styles/_ScoreRenderer.scss
@@ -7,7 +7,7 @@
   }
   .ScoreRenderer__domain {
     display: flex;
-    width: 300px;
+    width: 400px;
   }
   .ScoreRenderer__domain__section {
     padding: 10px;
@@ -20,5 +20,6 @@
   }
 }
 .ant-tooltip-inner {
-  width: 300px !important;
+  background-color: rgba(0, 0, 0, 0.9);
+  width: 400px !important;
 }

--- a/src/styles/_ScoreRenderer.scss
+++ b/src/styles/_ScoreRenderer.scss
@@ -18,6 +18,9 @@
       padding: 0;
     }
   }
+  .unit {
+    font-size: 12px;
+  }
 }
 .ant-tooltip-inner {
   background-color: rgba(0, 0, 0, 0.9);


### PR DESCRIPTION
This is related to #652 

This is how the tooltip looks like after the suggested changes:
<img width="490" alt="Schermata 2019-05-14 alle 18 36 54" src="https://user-images.githubusercontent.com/7654979/57715924-18753b80-7678-11e9-9a07-9ab5b6f8a126.png">

This implementation still miss one of the suggested changes, about link the titles to a document, that is not yet be written.
