### PR TITLE
introduce 'OTHER' as a choice for curating license

### DIFF
--- a/src/components/LicensePicker/utils.js
+++ b/src/components/LicensePicker/utils.js
@@ -10,7 +10,7 @@ const NOASSERTION = 'NOASSERTION'
 // Shared methods appliable to License Picker
 export default class LicensePickerUtils {
   static parseLicense(license) {
-    return license && !['NONE', 'NOASSERTION', 'PRESENCE OF', 'ABSENCE OF'].includes(license)
+    return license && !['NONE', 'NOASSERTION', 'OTHER', 'PRESENCE OF', 'ABSENCE OF'].includes(license)
       ? parse(license)
       : { license }
   }

--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -184,7 +184,12 @@ class PageBrowse extends SystemManagedList {
           />
         </div>
         <div className="filter-list">
-          <SpdxPicker value={''} promptText={'License'} onChange={value => this.onFilter({ type: 'license', value })} />
+          <SpdxPicker
+            value={''}
+            promptText={'License'}
+            onChange={value => this.onFilter({ type: 'license', value })}
+            customIdentifiers={['NOASSERTION', '']}
+          />
           &nbsp;
           <SortList list={sorts} title={'Sort By'} id={'sort'} value={this.state.activeSort} onSort={this.onSort} />
           &nbsp; &nbsp; &nbsp; &nbsp;

--- a/src/components/Navigation/Sections/FilterBar.js
+++ b/src/components/Navigation/Sections/FilterBar.js
@@ -99,7 +99,7 @@ export default class FilterBar extends Component {
               disabled={hasComponents}
               promptText={'License'}
               onChange={value => onFilter({ type: 'licensed.declared', value })}
-              customIdentifiers={['PRESENCE OF', 'ABSENCE OF', '']}
+              customIdentifiers={['NOASSERTION', 'PRESENCE OF', 'ABSENCE OF', '']}
             />
           )}
           {showSourceFilter && (

--- a/src/components/SystemManagedList.js
+++ b/src/components/SystemManagedList.js
@@ -203,7 +203,7 @@ export default class SystemManagedList extends Component {
         if (value === 'PRESENCE OF') {
           if (!fieldValue) return false
         } else if (value === 'ABSENCE OF') {
-          if (fieldValue && !['NONE', 'NOASSERTION'].includes(fieldValue)) return false
+          if (fieldValue && !['NONE', 'NOASSERTION', 'OTHER'].includes(fieldValue)) return false
         } else {
           if (!fieldValue || !fieldValue.toLowerCase().includes(value.toLowerCase())) {
             return false

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -51,7 +51,7 @@ function paramsToObject(entries) {
   return result
 }
 
-const customLicenseIds = ['NONE', 'NOASSERTION']
+const customLicenseIds = ['NONE', 'OTHER']
 
 const sorts = [
   { value: 'license', label: 'License' },


### PR DESCRIPTION
This is the idea:
- NOASSERTION is a machine only term
- curations can choose from NONE / OTHER / SPDX

This is meant to short circuit the curation infinite loop.
If you pick up a component that is NOASSERTION, you can mark it as NONE or OTHER and move on

---

### picking a license for curation:

![image](https://user-images.githubusercontent.com/5168796/57890195-cf45f880-77eb-11e9-8707-717594275c43.png)


### filtering on homepage:

![image](https://user-images.githubusercontent.com/5168796/57890212-d967f700-77eb-11e9-83ff-43c6fe2d887c.png)

### filtering on workspace:

![image](https://user-images.githubusercontent.com/5168796/57890227-e4228c00-77eb-11e9-91ae-acc30e5d417e.png)
