### PR TITLE
Fix scoring formula using maxScore for each param

### DIFF
--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -50,7 +50,7 @@ class ScoreRenderer extends Component {
     return (
       <p style={{ color }}>
         {label}: {score[name]}
-        {this.renderUnit()}
+        {this.renderUnit(maxScores[name])}
       </p>
     )
   }
@@ -105,7 +105,7 @@ class ScoreRenderer extends Component {
     )
   }
 
-  renderUnit = () => <span>/100</span>
+  renderUnit = maxScore => <span>/{maxScore || 100}</span>
 
   renderScoreInfo = () => (
     <div className="ScoreInfo">

--- a/src/components/Navigation/Ui/ScoreRenderer.js
+++ b/src/components/Navigation/Ui/ScoreRenderer.js
@@ -105,7 +105,7 @@ class ScoreRenderer extends Component {
     )
   }
 
-  renderUnit = maxScore => <span>/{maxScore || 100}</span>
+  renderUnit = maxScore => <span>{`/${maxScore || 100}`}</span>
 
   renderScoreInfo = () => (
     <div className="ScoreInfo">


### PR DESCRIPTION
With this fix, each param has as a unit the right total amount as explained by the Scoring Formula document.

![Schermata 2019-06-05 alle 15 15 44](https://user-images.githubusercontent.com/7654979/58959212-dd60b680-87a4-11e9-9dcc-197a6f170588.png)
