### PR TITLE
Added Tooltip to DefinitionTitle

### DIFF
--- a/src/components/Navigation/Ui/DefinitionTitle.js
+++ b/src/components/Navigation/Ui/DefinitionTitle.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import get from 'lodash/get'
+import Tooltip from 'antd/lib/tooltip'
 
 class DefinitionTitle extends Component {
   static propTypes = {
@@ -14,22 +15,35 @@ class DefinitionTitle extends Component {
     showNamespace: true
   }
 
-  render() {
+  renderDefinitionTitle = () => {
     const { definition, showNamespace } = this.props
+    return (
+      <>
+        {showNamespace && definition.coordinates.namespace ? definition.coordinates.namespace + '/' : ''}
+        {definition.coordinates.name}
+      </>
+    )
+  }
+
+  render() {
+    const { definition } = this.props
     return get(definition, 'described.urls.registry') ? (
       <span>
-        <a
-          href={get(definition, 'described.urls.registry')}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-test-id="component-name"
-        >
-          {showNamespace && definition.coordinates.namespace ? definition.coordinates.namespace + '/' : ''}
-          {definition.coordinates.name}
-        </a>
+        <Tooltip title={this.renderDefinitionTitle()}>
+          <a
+            href={get(definition, 'described.urls.registry')}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-test-id="component-name"
+          >
+            {this.renderDefinitionTitle()}
+          </a>
+        </Tooltip>
       </span>
     ) : (
-      <span data-test-id="component-name">{definition.coordinates.name}</span>
+      <Tooltip title={this.renderDefinitionTitle()}>
+        <span data-test-id="component-name">{this.renderDefinitionTitle()}</span>
+      </Tooltip>
     )
   }
 }

--- a/src/styles/_FullDetailComponent.scss
+++ b/src/styles/_FullDetailComponent.scss
@@ -31,7 +31,7 @@
   .header-title {
     display: flex;
     align-items: center;
-    max-width: 80%;
+    max-width: 70%;
     h2 {
       margin: 0;
       padding: 0;
@@ -39,13 +39,14 @@
       max-width: 100%;
       a {
         width: 100%;
-        word-wrap: break-word;
+        overflow: hidden;
+        text-overflow: ellipsis;
         display: inline-block;
       }
-      .header-data {
-        display: flex;
-        align-items: center;
-      }
+    }
+    .header-data {
+      display: flex;
+      align-items: center;
     }
   }
   p {


### PR DESCRIPTION
Resolves #752 

Since the definition title could be very long in some cases, the best way is to cut it off at a fixed width, and then show a tooltip over it.