### PR TITLE
Warning message for users without a public email

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -7,8 +7,8 @@ import { uiRedirect } from './ui'
 export const LOGIN = 'LOGIN'
 export const LOGOUT = 'LOGOUT'
 
-export function login(token, permissions, username) {
-  return dispatch => dispatch({ type: LOGIN, token, permissions, username })
+export function login(token, permissions, username, publicEmails) {
+  return dispatch => dispatch({ type: LOGIN, token, permissions, username, publicEmails })
 }
 
 export function logout(error) {

--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -112,7 +112,6 @@ export default class ContributePrompt extends Component {
   render() {
     const { details, summary, show, resolution } = this.state
     const { session, onLogin } = this.props
-    console.log(session)
     return (
       <Modal show={show} id="contribute-modal">
         <Form>
@@ -120,7 +119,7 @@ export default class ContributePrompt extends Component {
             <Modal.Title>Describe the changes in this curation</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            {!session.publicEmails && (
+            {!session.isAnonymous && !session.publicEmails && (
               <Alert bsStyle="warning">
                 Since you set your email as private on your GitHub profile, you can submit this contribution but the
                 commits would not be attributed to you.

--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -112,6 +112,7 @@ export default class ContributePrompt extends Component {
   render() {
     const { details, summary, show, resolution } = this.state
     const { session, onLogin } = this.props
+    console.log(session)
     return (
       <Modal show={show} id="contribute-modal">
         <Form>

--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -3,7 +3,7 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Modal, Form, Button } from 'react-bootstrap'
+import { Modal, Form, Button, Alert } from 'react-bootstrap'
 import { FormGroup, ControlLabel, FormControl, Checkbox } from 'react-bootstrap'
 import { FieldGroup } from './'
 import Contribution from '../utils/contribution'
@@ -23,7 +23,8 @@ export default class ContributePrompt extends Component {
     onLogin: PropTypes.func.isRequired,
     session: PropTypes.shape({
       isAnonymous: PropTypes.bool,
-      username: PropTypes.string
+      username: PropTypes.string,
+      publicEmails: PropTypes.bool
     }).isRequired
   }
 
@@ -93,7 +94,7 @@ export default class ContributePrompt extends Component {
             definitions.map(definition => {
               const image = Contribution.getImage({ coordinates: definition })
               return (
-                <li>
+                <li key={image}>
                   {image && <img className="list-image" src={image} alt="" />}
                   <span className="definition-name">
                     {definition.namespace && `${definition.namespace}/`}
@@ -111,7 +112,6 @@ export default class ContributePrompt extends Component {
   render() {
     const { details, summary, show, resolution } = this.state
     const { session, onLogin } = this.props
-
     return (
       <Modal show={show} id="contribute-modal">
         <Form>
@@ -119,6 +119,12 @@ export default class ContributePrompt extends Component {
             <Modal.Title>Describe the changes in this curation</Modal.Title>
           </Modal.Header>
           <Modal.Body>
+            {!session.publicEmails && (
+              <Alert bsStyle="warning">
+                Since you set your email as private on your GitHub profile, you can submit this contribution but the
+                commits would not be attributed to you.
+              </Alert>
+            )}
             <div className="container" style={{ display: 'flex' }}>
               <div className="contribution-container">
                 <div>

--- a/src/components/ContributePrompt.js
+++ b/src/components/ContributePrompt.js
@@ -121,8 +121,8 @@ export default class ContributePrompt extends Component {
           <Modal.Body>
             {!session.isAnonymous && !session.publicEmails && (
               <Alert bsStyle="warning">
-                Since you set your email as private on your GitHub profile, you can submit this contribution but the
-                commits would not be attributed to you.
+                Since your email is set as private on your GitHub profile, you can submit this contribution but the
+                commits will not be attributed to you.
               </Alert>
             )}
             <div className="container" style={{ display: 'flex' }}>

--- a/src/components/FullDetailView/FullDetailPage.js
+++ b/src/components/FullDetailView/FullDetailPage.js
@@ -247,8 +247,8 @@ export class FullDetailPage extends AbstractFullDetailsView {
 
   handleLogin(e) {
     e.preventDefault()
-    Auth.doLogin((token, permissions, username) => {
-      this.props.login(token, permissions, username)
+    Auth.doLogin((token, permissions, username, publicEmails) => {
+      this.props.login(token, permissions, username, publicEmails)
     })
   }
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -26,8 +26,8 @@ class Header extends Component {
 
   handleLogin(e) {
     e.preventDefault()
-    Auth.doLogin((token, permissions, username) => {
-      this.props.dispatch(login(token, permissions, username))
+    Auth.doLogin((token, permissions, username, publicEmails) => {
+      this.props.dispatch(login(token, permissions, username, publicEmails))
     })
   }
 

--- a/src/components/SystemManagedList.js
+++ b/src/components/SystemManagedList.js
@@ -365,8 +365,8 @@ export default class SystemManagedList extends Component {
 
   handleLogin(e) {
     e.preventDefault()
-    Auth.doLogin((token, permissions, username) => {
-      this.props.dispatch(login(token, permissions, username))
+    Auth.doLogin((token, permissions, username, publicEmails) => {
+      this.props.dispatch(login(token, permissions, username, publicEmails))
     })
   }
 

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -18,7 +18,8 @@ export default function sessionReducer(state = initialState, action) {
         isAnonymous: false,
         token: action.token,
         permissions: action.permissions,
-        username: action.username
+        username: action.username,
+        publicEmails: action.publicEmails
       }
     case LOGOUT:
       return { ...initialState }

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -11,7 +11,7 @@ export default class Auth {
     window.open(url('auth/github'))
     const tokenListener = e => {
       if (e.data.type === 'github-token') {
-        callback(e.data.token, e.data.permissions, e.data.username)
+        callback(e.data.token, e.data.permissions, e.data.username, e.data.publicEmails)
         window.removeEventListener('message', tokenListener)
       }
     }


### PR DESCRIPTION
This follow https://github.com/clearlydefined/service/pull/578 and resolves #778 adding a warning message for all the users that haven't a public email on their GitHub profile.

![Schermata 2019-07-10 alle 19 07 00](https://user-images.githubusercontent.com/7654979/60989411-3db7ba80-a346-11e9-9115-82ec3520cfdb.png)

This will remain a Draft PR until https://github.com/clearlydefined/service/pull/578 would not be merged on the service.