### PR TITLE
Adding harvest indicator on full detail page

### DIFF
--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -169,7 +169,7 @@ class FullDetailComponent extends Component {
         )}
         <Row>
           <Col md={1} xs={2}>
-            {image && <img className="list-image" src={image} alt="" />}
+            {image && <img className="component-image" src={image} alt="" />}
           </Col>
           <Col md={11} xs={10}>
             <HeaderSection {...this.props} />

--- a/src/components/Navigation/Sections/HeaderSection.js
+++ b/src/components/Navigation/Sections/HeaderSection.js
@@ -12,6 +12,7 @@ import ScoreRenderer from '../Ui/ScoreRenderer'
 import DefinitionTitle from '../Ui/DefinitionTitle'
 import DefinitionRevision from '../Ui/DefinitionRevision'
 import ComponentDetailsButtons from '../Ui/ComponentDetailsButtons'
+import HarvestIndicator from '../Ui/HarvestIndicator'
 
 class HeaderSection extends Component {
   static propTypes = {
@@ -46,28 +47,28 @@ class HeaderSection extends Component {
       <Row className="row-detail-header">
         <Col md={8}>
           <div className="detail-header">
+            <div className="header-data">
+              {scores && (
+                <span className="score-header">
+                  <ScoreRenderer scores={scores} definition={item} />
+                </span>
+              )}
+              {isCurated && (
+                <Tag className="cd-badge" color="purple">
+                  Curated
+                </Tag>
+              )}
+              {hasPendingCurations && (
+                <Tag className="cd-badge" color="green">
+                  Pending curations
+                </Tag>
+              )}
+              <HarvestIndicator tools={get(item, 'described.tools')} />
+            </div>
             <div className="header-title">
               <h2>
                 <DefinitionTitle definition={item} showNamespace={false} />
               </h2>
-              &nbsp;&nbsp;
-              <div className="header-data">
-                {scores && (
-                  <span className="score-header">
-                    <ScoreRenderer scores={scores} definition={item} />
-                  </span>
-                )}
-                {isCurated && (
-                  <Tag className="cd-badge" color="purple">
-                    Curated
-                  </Tag>
-                )}
-                {hasPendingCurations && (
-                  <Tag className="cd-badge" color="green">
-                    Pending curations
-                  </Tag>
-                )}
-              </div>
               <div>
                 <ComponentDetailsButtons item={item} />
               </div>

--- a/src/components/Navigation/Ui/HarvestIndicator.js
+++ b/src/components/Navigation/Ui/HarvestIndicator.js
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+import React, { Component } from 'react'
+import { Tag, Tooltip } from 'antd'
+
+class HarvestIndicator extends Component {
+  getColor = tools => {
+    const colors = ['#cb2431', '#d6af22', '#2cbe4e']
+    return colors[tools.length > 2 ? 2 : tools.length]
+  }
+  getHarvestStatus = tools => {
+    const status = ['Not Harvested', 'Partially Harvested', 'Harvested']
+    return status[tools.length > 2 ? 2 : tools.length]
+  }
+  getTooltip = tools => {
+    const tooltip = ['Not Harvested', 'Partially Harvested', 'Harvested']
+    return tooltip[tools.length > 2 ? 2 : tools.length]
+  }
+  render() {
+    const { tools } = this.props
+    return (
+      <Tooltip title={this.getTooltip(tools)}>
+        <Tag className="cd-badge" color={this.getColor(tools)}>
+          {this.getHarvestStatus(tools)}
+        </Tag>
+      </Tooltip>
+    )
+  }
+}
+
+export default HarvestIndicator

--- a/src/styles/_FullDetailComponent.scss
+++ b/src/styles/_FullDetailComponent.scss
@@ -24,6 +24,11 @@
   }
 }
 
+.component-image {
+  height: 80px;
+  width: 80px;
+}
+
 .detail-header {
   align-items: baseline;
   margin: 0;
@@ -37,6 +42,7 @@
       padding: 0;
       font-size: 2.5em;
       max-width: 100%;
+      margin-right: 30px;
       a {
         width: 100%;
         overflow: hidden;


### PR DESCRIPTION
Resolves #742 

Adding an Harvest Status Indicator to the Full Detail Page, i've also changed a little bit the view of the section in order to give some space to all the indicators.
Now the heading section looks like this:
<img width="452" alt="Schermata 2019-08-20 alle 22 46 47" src="https://user-images.githubusercontent.com/7654979/63383390-f6890480-c39c-11e9-9182-6a838ca07636.png">
<img width="633" alt="Schermata 2019-08-20 alle 22 46 42" src="https://user-images.githubusercontent.com/7654979/63383391-f6890480-c39c-11e9-9cea-e6a0765d9cad.png">
