### PR TITLE
Add deb and debsrc stats

### DIFF
--- a/src/components/Navigation/Pages/PageStats/PageStats.js
+++ b/src/components/Navigation/Pages/PageStats/PageStats.js
@@ -28,7 +28,8 @@ const types = {
   nuget: nuget,
   git: git,
   crate: crate,
-  debian: debian,
+  deb: debian,
+  debsrc: debian,
   composer: composer,
   pod: pod
 }


### PR DESCRIPTION
I've modified Debian stats in order to check for `deb` param.
I've also added a card for `debsrc`, but the call to the service fails:
<img width="421" alt="Schermata 2019-10-23 alle 10 05 36" src="https://user-images.githubusercontent.com/7654979/67371707-185d5e00-f57d-11e9-9fa1-aba97bb4b9a2.png">

Fixes #836 
