### PR TITLE
Fixes Stats active status in the navigation bar

### DIFF
--- a/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
+++ b/src/components/Navigation/Pages/PageStats/LicenseBreakdown.js
@@ -57,13 +57,13 @@ export default class LicenseBreakdown extends Component {
               data={stats.declaredLicenseBreakdown}
               margin={{ top: 5, right: 0, left: 0, bottom: 25 }}
             >
-              <XAxis dataKey="value" tickSize dy="25" />
+              <XAxis dataKey="value" tickSize={10} dy={5} />
               <YAxis hide />
               <Tooltip />
               <CartesianGrid vertical={false} stroke="#ebf3f0" />
               <Bar dataKey="count" barSize={170}>
                 {stats.declaredLicenseBreakdown.map((entry, index) => (
-                  <Cell fill={colors[index % colors.length]} />
+                  <Cell fill={colors[index % colors.length]} key={index} />
                 ))}
               </Bar>
             </BarChart>

--- a/src/components/Navigation/Pages/PageStats/PageStats.js
+++ b/src/components/Navigation/Pages/PageStats/PageStats.js
@@ -19,6 +19,8 @@ import composer from '../../../../images/packagist.png'
 import gem from '../../../../images/gem.png'
 import pypi from '../../../../images/pypi.png'
 import debian from '../../../../images/debian.png'
+import { uiNavigation } from '../../../../actions/ui'
+import { ROUTE_STATS } from '../../../../utils/routingConstants'
 
 const types = {
   npm: npm,
@@ -41,6 +43,7 @@ class PageStats extends Component {
   }
 
   async componentDidMount() {
+    this.props.dispatch(uiNavigation({ to: ROUTE_STATS }))
     await Promise.all([
       this.props.dispatch(getStatAction('total')),
       ...Object.keys(types).map(type => this.props.dispatch(getStatAction(type)))
@@ -65,19 +68,19 @@ class PageStats extends Component {
         <Row>
           <div className="card-container">
             {Object.keys(types).map(type => (
-              <TypeCard type={type} image={types[type]} stats={get(stats, `entries.${type}.value`)} />
+              <TypeCard type={type} image={types[type]} stats={get(stats, `entries.${type}.value`)} key={type}/>
             ))}
           </div>
         </Row>
         <hr />
         <Row>
           <h2>Declared License Breakdown</h2>
-          <Tabs>
+          <Tabs id="packages">
             <Tab eventKey="overall" title="Overall">
               <LicenseBreakdown type="total" stats={get(stats, 'entries.total.value')} />
             </Tab>
             {Object.keys(types).map(type => (
-              <Tab eventKey={type} title={type}>
+              <Tab eventKey={type} title={type} key={type}>
                 <LicenseBreakdown type="total" stats={get(stats, `entries.${type}.value`)} />
               </Tab>
             ))}


### PR DESCRIPTION
PageStats component now properly dispatches the uiNavigation message

In addition several React errors were fixed in...
1. PageStats
   - TypeCard given an unique "key" prop.
   - Tabs require an id for accessibility
   - Tab given an unique "key" prop.
2. LicenseBreakdown
   - XAxis
     + tickSize data type changed to integer (from boolean)
     + dy properly set to JSX integer expression (from string)
   - Cell given an unique "key" prop.

Signed-off-by: Tom Marble <tmarble@info9.net>