### PR TITLE
clarifies behavior to expect from the curations page when displaying …

### DIFF
--- a/src/components/Navigation/Pages/PageContribution/PageContribution.js
+++ b/src/components/Navigation/Pages/PageContribution/PageContribution.js
@@ -27,7 +27,7 @@ class PageContribution extends SystemManagedList {
   }
 
   noRowsRenderer() {
-    return <div className="placeholder-message">Fetching details on the components included in the pull request.</div>
+    return <div className="placeholder-message">No open (unmerged) definitions found in this pull request</div>
   }
 
   tableTitle() {
@@ -37,9 +37,9 @@ class PageContribution extends SystemManagedList {
         #{prNumber}
       </a>
     ) : (
-      `#${prNumber}`
-    )
-    return <span>Definitions from pull request {linkBack}</span>
+        `#${prNumber}`
+      )
+    return <span>Open (unmerged) definitions from pull request {linkBack}</span>
   }
 
   renderButtons() {


### PR DESCRIPTION
…definitions included in pull requests

This is a "for now" fix for #885. After consulting with stakeholders and others, it seems the simplest solution for the moment.

The underlying problem is in the way we find definitions to display from a pull request. At the moment (and this may be intended behavior), we take all the definitions for the component in the PR branch and compare it to the current master branch. We then subtract the revisions that appear in the master branch from the ones in the PR branch. This works fine with a PR is not yet merged, but it does not work after the PR is merged, all the revisions in the PR will then be in the master branch.

This updates the messages that are displayed to the user on the curations page. It more accurately communicates the intended behavior of the page.

As I become more comfortable in React, I imagine I will be able to devise a more elegant solution, but this solves the immediate problem of user confusion.

Signed-off-by: Nell Shamrell <nells@microsoft.com>