### PR TITLE
shows harvest option in the nav bar to everyone

### DIFF
--- a/src/reducers/navigationReducer.js
+++ b/src/reducers/navigationReducer.js
@@ -20,9 +20,8 @@ const initialState = [
   {
     title: 'Harvest',
     to: ROUTE_HARVEST,
-    protected: 1,
+    protected: 0,
     isSelected: false,
-    permissions: ['harvest']
   },
   {
     title: 'About',


### PR DESCRIPTION
I was troubleshooting another bug and noticed the views related to Harvesting, which I had no way of seeing or knowing that they exist. This is because it only showed in the nav bar for users who had the harvest permission. However, even though the option in the nav bar was hidden, anyone could visit https://clearlydefined.io/harvest and kick off a harvest. Additionally, anytime someone visits the definitions page for a component (for example, https://clearlydefined.io/definitions/npm/npmjs/-/split.js/1.6.3) and that component has not been harvested, a harvest is automatically queued. 

There doesn't seem to be a compelling reason to lock down the Harvest option in the nav bar. Additionally, having it visible ensures that we are aware of it and remember that it exists.

Signed-off-by: Nell Shamrell <nells@microsoft.com>