### PR TITLE
Footer: updating wording and linking to OSI

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -34,10 +34,11 @@ export default class Footer extends Component {
             <SocialIcons className="clearly-footer-socials pb-2" entity={socials} />
             <div className="col-md-8">
               <p class="mb-0">
-                ClearlyDefined was created by
-                <Link to="/" className="mx-1 highlighted-link-blue">Microsoft</Link>
-                in partnership with the
-                <Link to="/" className="mx-1 highlighted-link-blue">Open Source Initiative.</Link>
+                ClearlyDefined is an 
+                <a href="https://opensource.org" className="mx-1 highlighted-link-blue">OSI</a> incubator project, 
+                originally contributed with ❤️ by 
+                <a href="https://opensource.microsoft.com" className="mx-1 highlighted-link-blue">Microsoft</a> 
+                and maintained by a growing community.
               </p>
             </div>
             <div className="col-md-4 footer-links col-12 ml-md-auto mt-md-0 mt-4">


### PR DESCRIPTION
Evolving the footer for the website, "ClearlyDefined is an OSI incubator project, originally contributed with ❤️ by Microsoft and maintained by a growing community"