### PR TITLE
Fix file listing on reverting changes

### DIFF
--- a/src/components/FileList/FileList.js
+++ b/src/components/FileList/FileList.js
@@ -38,10 +38,6 @@ export default class FileList extends PureComponent {
     this.updateFileList(this.props)
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.updateFileList(nextProps)
-  }
-
   updateFileList = props => {
     this.setState({
       files: FileListSpec.pathToTreeFolders(props.files, props.component.item, props.previewDefinition)


### PR DESCRIPTION
The files state should only be modiified when directory is changed (onDirectorySelect)  or clicking breadcrumbs (onBreadcrumbSelect)

https://github.com/clearlydefined/website/issues/975