### PR TITLE
Moved package selectors and version pickers

### DIFF
--- a/src/components/Providers/Selectors/CocoaPodsSelector.js
+++ b/src/components/Providers/Selectors/CocoaPodsSelector.js
@@ -1,21 +1,21 @@
-// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
+// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getPyPiSearch } from '../api/clearlyDefined'
+import { getCocoaPodsSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 
-export default class PyPiSelector extends Component {
+export default class CocoaPodsSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
 
   constructor(props) {
     super(props)
-    this.state = { isLoading: false, options: [], focus: false }
+    this.state = { isLoading: false, options: [], focus: true }
     this.getOptions = this.getOptions.bind(this)
     this.onChange = this.onChange.bind(this)
   }
@@ -23,13 +23,13 @@ export default class PyPiSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'pypi', provider: 'pypi', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'pod', provider: 'cocoapods', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getPyPiSearch(this.props.token, value)
+      const options = await getCocoaPodsSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -44,11 +44,11 @@ export default class PyPiSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="pypi-selector"
+          id="pod-selector"
           className="harvest-search"
           useCache={false}
           options={options}
-          placeholder={'Pick a PyPi to harvest'}
+          placeholder={'Pick a CocoaPod to harvest'}
           onChange={this.onChange}
           labelKey="id"
           onFocus={() => this.setState({ ...this.state, focus: true })}

--- a/src/components/Providers/Selectors/ComposerSelector.js
+++ b/src/components/Providers/Selectors/ComposerSelector.js
@@ -3,19 +3,18 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getRubyGemsSearch } from '../api/clearlyDefined'
+import { getComposerSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
-import 'react-bootstrap-typeahead/css/Typeahead.css'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class RubyGemsSelector extends Component {
+export default class ComposerSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
 
   constructor(props) {
     super(props)
-    this.state = { isLoading: false, options: [], focus: true }
+    this.state = { isLoading: false, options: [], focus: false }
     this.getOptions = this.getOptions.bind(this)
     this.onChange = this.onChange.bind(this)
   }
@@ -23,13 +22,13 @@ export default class RubyGemsSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'gem', provider: 'rubygems', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'composer', provider: 'packagist', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getRubyGemsSearch(this.props.token, value)
+      const options = await getComposerSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -44,11 +43,11 @@ export default class RubyGemsSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="ruby-selector"
+          id="composer-selector"
           className="harvest-search"
           useCache={false}
           options={options}
-          placeholder={'Pick a RubyGem to harvest'}
+          placeholder={'Pick a Composer to harvest'}
           onChange={this.onChange}
           labelKey="id"
           onFocus={() => this.setState({ ...this.state, focus: true })}

--- a/src/components/Providers/Selectors/CrateSelector.js
+++ b/src/components/Providers/Selectors/CrateSelector.js
@@ -1,21 +1,20 @@
-// (c) Copyright 2022, SAP SE and ClearlyDefined contributors. Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation and others. Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getCocoaPodsSearch } from '../api/clearlyDefined'
+import { getCrateSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
-import 'react-bootstrap-typeahead/css/Typeahead.css'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class CocoaPodsSelector extends Component {
+export default class CrateSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
 
   constructor(props) {
     super(props)
-    this.state = { isLoading: false, options: [], focus: true }
+    this.state = { isLoading: false, options: [], focus: false }
     this.getOptions = this.getOptions.bind(this)
     this.onChange = this.onChange.bind(this)
   }
@@ -23,13 +22,13 @@ export default class CocoaPodsSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'pod', provider: 'cocoapods', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'crate', provider: 'cratesio', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getCocoaPodsSearch(this.props.token, value)
+      const options = await getCrateSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -44,11 +43,11 @@ export default class CocoaPodsSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="pod-selector"
+          id="crate-selector"
           className="harvest-search"
           useCache={false}
           options={options}
-          placeholder={'Pick a CocoaPod to harvest'}
+          placeholder={'Pick a Crate to harvest'}
           onChange={this.onChange}
           labelKey="id"
           onFocus={() => this.setState({ ...this.state, focus: true })}

--- a/src/components/Providers/Selectors/GitHubSelector.js
+++ b/src/components/Providers/Selectors/GitHubSelector.js
@@ -3,9 +3,9 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getGitHubSearch } from '../api/clearlyDefined'
+import { getGitHubSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 
 export default class GitHubSelector extends Component {

--- a/src/components/Providers/Selectors/MavenSelector.js
+++ b/src/components/Providers/Selectors/MavenSelector.js
@@ -3,9 +3,9 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getMavenSearch } from '../api/clearlyDefined'
+import { getMavenSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 
 export default class MavenSelector extends Component {

--- a/src/components/Providers/Selectors/NpmSelector.js
+++ b/src/components/Providers/Selectors/NpmSelector.js
@@ -3,11 +3,12 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getNugetSearch } from '../api/clearlyDefined'
+import { getNpmSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
+import 'react-bootstrap-typeahead/css/Typeahead.css'
 
-export default class NuGetSelector extends Component {
+export default class NpmSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
@@ -22,13 +23,13 @@ export default class NuGetSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'nuget', provider: 'nuget', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'npm', provider: 'npmjs', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getNugetSearch(this.props.token, value)
+      const options = await getNpmSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -43,16 +44,17 @@ export default class NuGetSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="nuget-selector"
+          id="npm-selector"
           className="harvest-search"
+          inputProps={{ dataTestId: 'npm-selector' }}
           useCache={false}
           options={options}
-          placeholder={'Pick a Nuget to harvest'}
+          placeholder={'Select an NPM component'}
           onChange={this.onChange}
-          labelKey="id"
-          clearButton
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
+          labelKey="id"
+          clearButton
           highlightOnlyResult
           emptyLabel=""
           selectHintOnEnter

--- a/src/components/Providers/Selectors/NuGetSelector.js
+++ b/src/components/Providers/Selectors/NuGetSelector.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getComposerSearch } from '../api/clearlyDefined'
+import { getNugetSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class ComposerSelector extends Component {
+export default class NuGetSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
@@ -22,13 +22,13 @@ export default class ComposerSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'composer', provider: 'packagist', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'nuget', provider: 'nuget', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getComposerSearch(this.props.token, value)
+      const options = await getNugetSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -43,16 +43,16 @@ export default class ComposerSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="composer-selector"
+          id="nuget-selector"
           className="harvest-search"
           useCache={false}
           options={options}
-          placeholder={'Pick a Composer to harvest'}
+          placeholder={'Pick a Nuget to harvest'}
           onChange={this.onChange}
           labelKey="id"
+          clearButton
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
-          clearButton
           highlightOnlyResult
           emptyLabel=""
           selectHintOnEnter

--- a/src/components/Providers/Selectors/PyPiSelector.js
+++ b/src/components/Providers/Selectors/PyPiSelector.js
@@ -3,12 +3,12 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getNpmSearch } from '../api/clearlyDefined'
+import { getPyPiSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 
-export default class NpmSelector extends Component {
+export default class PyPiSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
@@ -23,13 +23,13 @@ export default class NpmSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'npm', provider: 'npmjs', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'pypi', provider: 'pypi', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getNpmSearch(this.props.token, value)
+      const options = await getPyPiSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -44,16 +44,15 @@ export default class NpmSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="npm-selector"
+          id="pypi-selector"
           className="harvest-search"
-          inputProps={{ dataTestId: 'npm-selector' }}
           useCache={false}
           options={options}
-          placeholder={'Select an NPM component'}
+          placeholder={'Pick a PyPi to harvest'}
           onChange={this.onChange}
+          labelKey="id"
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
-          labelKey="id"
           clearButton
           highlightOnlyResult
           emptyLabel=""

--- a/src/components/Providers/Selectors/RubyGemsSelector.js
+++ b/src/components/Providers/Selectors/RubyGemsSelector.js
@@ -3,18 +3,19 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getCrateSearch } from '../api/clearlyDefined'
+import { getRubyGemsSearch } from '../../../api/clearlyDefined'
 import { AsyncTypeahead } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
+import searchSvg from '../../../images/icons/searchSvg.svg'
+import 'react-bootstrap-typeahead/css/Typeahead.css'
 
-export default class CrateSelector extends Component {
+export default class RubyGemsSelector extends Component {
   static propTypes = {
     onChange: PropTypes.func
   }
 
   constructor(props) {
     super(props)
-    this.state = { isLoading: false, options: [], focus: false }
+    this.state = { isLoading: false, options: [], focus: true }
     this.getOptions = this.getOptions.bind(this)
     this.onChange = this.onChange.bind(this)
   }
@@ -22,13 +23,13 @@ export default class CrateSelector extends Component {
   onChange(values) {
     const { onChange } = this.props
     const value = values.length === 0 ? null : values[0]
-    value && onChange && onChange({ type: 'crate', provider: 'cratesio', name: value.id }, 'package')
+    value && onChange && onChange({ type: 'gem', provider: 'rubygems', name: value.id }, 'package')
   }
 
   async getOptions(value) {
     try {
       this.setState({ ...this.state, isLoading: true })
-      const options = await getCrateSearch(this.props.token, value)
+      const options = await getRubyGemsSearch(this.props.token, value)
       this.setState({ ...this.state, options, isLoading: false })
     } catch (error) {
       this.setState({ ...this.state, options: [], isLoading: false })
@@ -43,11 +44,11 @@ export default class CrateSelector extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <AsyncTypeahead
-          id="crate-selector"
+          id="ruby-selector"
           className="harvest-search"
           useCache={false}
           options={options}
-          placeholder={'Pick a Crate to harvest'}
+          placeholder={'Pick a RubyGem to harvest'}
           onChange={this.onChange}
           labelKey="id"
           onFocus={() => this.setState({ ...this.state, focus: true })}

--- a/src/components/Providers/VersionPickers/CocoaPodsVersionPicker.js
+++ b/src/components/Providers/VersionPickers/CocoaPodsVersionPicker.js
@@ -3,9 +3,9 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getCocoaPodsRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getCocoaPodsRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
 export default class CocoaPodsVersionPicker extends Component {
   static propTypes = {

--- a/src/components/Providers/VersionPickers/ComposerVersionPicker.js
+++ b/src/components/Providers/VersionPickers/ComposerVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getPyPiRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getComposerRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class PyPiVersionPicker extends Component {
+export default class ComposerVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -16,12 +16,7 @@ export default class PyPiVersionPicker extends Component {
 
   constructor(props) {
     super(props)
-    this.state = {
-      customValues: [],
-      options: [],
-      focus: false,
-      selected: props.request.revision ? [props.request.revision] : []
-    }
+    this.state = { customValues: [], options: [], focus: false }
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
   }
@@ -30,14 +25,10 @@ export default class PyPiVersionPicker extends Component {
     this.getOptions('')
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({ ...this.state, selected: nextProps.request.revision ? [nextProps.request.revision] : [] })
-  }
-
   async getOptions(value) {
     try {
-      const { name } = this.props.request
-      const options = await getPyPiRevisions(this.props.token, name)
+      const { name, namespace } = this.props.request
+      const options = await getComposerRevisions(this.props.token, `${namespace}/${name}`)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -63,7 +54,7 @@ export default class PyPiVersionPicker extends Component {
 
   render() {
     const { defaultInputValue } = this.props
-    const { customValues, options, selected, focus } = this.state
+    const { customValues, options, focus } = this.state
     const list = customValues.concat(options)
     return (
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
@@ -71,16 +62,17 @@ export default class PyPiVersionPicker extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <Autocomplete
-          id="pypi-version-picker"
-          selected={selected}
+          id="composer-version-picker"
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={options.length === 0 ? 'Could not fetch versions, type a PyPi version' : 'Pick a PyPi version'}
+          placeholder={
+            options.length === 0 ? 'Could not fetch versions, type a Composer version' : 'Pick a Composer version'
+          }
           onChange={this.onChange}
-          positionFixed
-          clearButton
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
+          positionFixed
+          clearButton
           allowNew
           newSelectionPrefix="Version:"
           emptyLabel=""

--- a/src/components/Providers/VersionPickers/CrateVersionPicker.js
+++ b/src/components/Providers/VersionPickers/CrateVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getNugetRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getCrateRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class NuGetVersionPicker extends Component {
+export default class CrateVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -16,12 +16,7 @@ export default class NuGetVersionPicker extends Component {
 
   constructor(props) {
     super(props)
-    this.state = {
-      customValues: [],
-      options: [],
-      selected: props.request.revision ? [props.request.revision] : [],
-      focus: false
-    }
+    this.state = { customValues: [], options: [], focus: false }
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
   }
@@ -30,14 +25,10 @@ export default class NuGetVersionPicker extends Component {
     this.getOptions('')
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({ ...this.state, selected: nextProps.request.revision ? [nextProps.request.revision] : [] })
-  }
-
   async getOptions(value) {
     try {
       const { name } = this.props.request
-      const options = await getNugetRevisions(this.props.token, name)
+      const options = await getCrateRevisions(this.props.token, name)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -63,31 +54,27 @@ export default class NuGetVersionPicker extends Component {
 
   render() {
     const { defaultInputValue } = this.props
-    const { customValues, options, selected, focus } = this.state
+    const { customValues, options, focus } = this.state
     const list = customValues.concat(options)
-
     return (
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
         <div className="search-logo">
           <img src={searchSvg} alt="search" />
-        </div>
+        </div>{' '}
         <Autocomplete
-          id="nuget-version-picker"
-          selected={selected}
+          id="crate-version-picker"
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={
-            options.length === 0 ? 'Could not fetch versions, type a Nuget version' : 'Pick an Nuget version'
-          }
+          placeholder={options.length === 0 ? 'Could not fetch versions, type a Crate version' : 'Pick a Crate version'}
           onChange={this.onChange}
           positionFixed
+          clearButton
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
-          clearButton
           allowNew
           newSelectionPrefix="Version:"
           emptyLabel=""
-          filterBy={this.filter}
+          // filterBy={this.filter}
           selectHintOnEnter
         />
       </div>

--- a/src/components/Providers/VersionPickers/GitHubCommitPicker.js
+++ b/src/components/Providers/VersionPickers/GitHubCommitPicker.js
@@ -4,8 +4,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Highlighter } from 'react-bootstrap-typeahead'
-import searchSvg from '../images/icons/searchSvg.svg'
-import Autocomplete from './Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
 
 export default class GitHubCommitPicker extends Component {
   static propTypes = {

--- a/src/components/Providers/VersionPickers/MavenVersionPicker.js
+++ b/src/components/Providers/VersionPickers/MavenVersionPicker.js
@@ -3,9 +3,9 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getMavenRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getMavenRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
 export default class MavenVersionPicker extends Component {
   static propTypes = {

--- a/src/components/Providers/VersionPickers/NpmVersionPicker.js
+++ b/src/components/Providers/VersionPickers/NpmVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getRubyGemsRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getNpmRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class RubyGemsVersionPicker extends Component {
+export default class NpmVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -36,8 +36,9 @@ export default class RubyGemsVersionPicker extends Component {
 
   async getOptions(value) {
     try {
-      const { name } = this.props.request
-      const options = await getRubyGemsRevisions(this.props.token, name)
+      const { namespace, name } = this.props.request
+      const path = namespace ? `${namespace}/${name}` : name
+      const options = await getNpmRevisions(this.props.token, path)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -69,15 +70,14 @@ export default class RubyGemsVersionPicker extends Component {
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
         <div className="search-logo">
           <img src={searchSvg} alt="search" />
-        </div>{' '}
+        </div>
         <Autocomplete
-          id="rubygems-version-picker"
+          id="npm-version-picker"
+          inputProps={{ dataTestId: 'npm-version-picker' }}
           selected={selected}
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={
-            options.length === 0 ? 'Could not fetch versions, type a RubyGem version' : 'Pick a RubyGem version'
-          }
+          placeholder={options.length === 0 ? 'Could not fetch versions, type an NPM version' : 'Pick an NPM version'}
           onChange={this.onChange}
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}

--- a/src/components/Providers/VersionPickers/NuGetVersionPicker.js
+++ b/src/components/Providers/VersionPickers/NuGetVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getNpmRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getNugetRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class NpmVersionPicker extends Component {
+export default class NuGetVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -19,8 +19,8 @@ export default class NpmVersionPicker extends Component {
     this.state = {
       customValues: [],
       options: [],
-      focus: false,
-      selected: props.request.revision ? [props.request.revision] : []
+      selected: props.request.revision ? [props.request.revision] : [],
+      focus: false
     }
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
@@ -36,9 +36,8 @@ export default class NpmVersionPicker extends Component {
 
   async getOptions(value) {
     try {
-      const { namespace, name } = this.props.request
-      const path = namespace ? `${namespace}/${name}` : name
-      const options = await getNpmRevisions(this.props.token, path)
+      const { name } = this.props.request
+      const options = await getNugetRevisions(this.props.token, name)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -66,22 +65,24 @@ export default class NpmVersionPicker extends Component {
     const { defaultInputValue } = this.props
     const { customValues, options, selected, focus } = this.state
     const list = customValues.concat(options)
+
     return (
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
         <div className="search-logo">
           <img src={searchSvg} alt="search" />
         </div>
         <Autocomplete
-          id="npm-version-picker"
-          inputProps={{ dataTestId: 'npm-version-picker' }}
+          id="nuget-version-picker"
           selected={selected}
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={options.length === 0 ? 'Could not fetch versions, type an NPM version' : 'Pick an NPM version'}
+          placeholder={
+            options.length === 0 ? 'Could not fetch versions, type a Nuget version' : 'Pick an Nuget version'
+          }
           onChange={this.onChange}
+          positionFixed
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
-          positionFixed
           clearButton
           allowNew
           newSelectionPrefix="Version:"

--- a/src/components/Providers/VersionPickers/PyPiVersionPicker.js
+++ b/src/components/Providers/VersionPickers/PyPiVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getComposerRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getPyPiRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class ComposerVersionPicker extends Component {
+export default class PyPiVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -16,7 +16,12 @@ export default class ComposerVersionPicker extends Component {
 
   constructor(props) {
     super(props)
-    this.state = { customValues: [], options: [], focus: false }
+    this.state = {
+      customValues: [],
+      options: [],
+      focus: false,
+      selected: props.request.revision ? [props.request.revision] : []
+    }
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
   }
@@ -25,10 +30,14 @@ export default class ComposerVersionPicker extends Component {
     this.getOptions('')
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({ ...this.state, selected: nextProps.request.revision ? [nextProps.request.revision] : [] })
+  }
+
   async getOptions(value) {
     try {
-      const { name, namespace } = this.props.request
-      const options = await getComposerRevisions(this.props.token, `${namespace}/${name}`)
+      const { name } = this.props.request
+      const options = await getPyPiRevisions(this.props.token, name)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -54,7 +63,7 @@ export default class ComposerVersionPicker extends Component {
 
   render() {
     const { defaultInputValue } = this.props
-    const { customValues, options, focus } = this.state
+    const { customValues, options, selected, focus } = this.state
     const list = customValues.concat(options)
     return (
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
@@ -62,17 +71,16 @@ export default class ComposerVersionPicker extends Component {
           <img src={searchSvg} alt="search" />
         </div>
         <Autocomplete
-          id="composer-version-picker"
+          id="pypi-version-picker"
+          selected={selected}
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={
-            options.length === 0 ? 'Could not fetch versions, type a Composer version' : 'Pick a Composer version'
-          }
+          placeholder={options.length === 0 ? 'Could not fetch versions, type a PyPi version' : 'Pick a PyPi version'}
           onChange={this.onChange}
-          onFocus={() => this.setState({ ...this.state, focus: true })}
-          onBlur={() => this.setState({ ...this.state, focus: false })}
           positionFixed
           clearButton
+          onFocus={() => this.setState({ ...this.state, focus: true })}
+          onBlur={() => this.setState({ ...this.state, focus: false })}
           allowNew
           newSelectionPrefix="Version:"
           emptyLabel=""

--- a/src/components/Providers/VersionPickers/RubyGemsVersionPicker.js
+++ b/src/components/Providers/VersionPickers/RubyGemsVersionPicker.js
@@ -3,11 +3,11 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { getCrateRevisions } from '../api/clearlyDefined'
-import Autocomplete from './Navigation/Ui/Autocomplete'
-import searchSvg from '../images/icons/searchSvg.svg'
+import { getRubyGemsRevisions } from '../../../api/clearlyDefined'
+import Autocomplete from '../../Navigation/Ui/Autocomplete'
+import searchSvg from '../../../images/icons/searchSvg.svg'
 
-export default class CrateVersionPicker extends Component {
+export default class RubyGemsVersionPicker extends Component {
   static propTypes = {
     onChange: PropTypes.func,
     request: PropTypes.object.isRequired,
@@ -16,7 +16,12 @@ export default class CrateVersionPicker extends Component {
 
   constructor(props) {
     super(props)
-    this.state = { customValues: [], options: [], focus: false }
+    this.state = {
+      customValues: [],
+      options: [],
+      focus: false,
+      selected: props.request.revision ? [props.request.revision] : []
+    }
     this.onChange = this.onChange.bind(this)
     this.filter = this.filter.bind(this)
   }
@@ -25,10 +30,14 @@ export default class CrateVersionPicker extends Component {
     this.getOptions('')
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({ ...this.state, selected: nextProps.request.revision ? [nextProps.request.revision] : [] })
+  }
+
   async getOptions(value) {
     try {
       const { name } = this.props.request
-      const options = await getCrateRevisions(this.props.token, name)
+      const options = await getRubyGemsRevisions(this.props.token, name)
       this.setState({ ...this.state, options })
     } catch (error) {
       this.setState({ ...this.state, options: [] })
@@ -54,7 +63,7 @@ export default class CrateVersionPicker extends Component {
 
   render() {
     const { defaultInputValue } = this.props
-    const { customValues, options, focus } = this.state
+    const { customValues, options, selected, focus } = this.state
     const list = customValues.concat(options)
     return (
       <div className={`harvest-searchbar ${focus ? 'active' : ''}`}>
@@ -62,19 +71,22 @@ export default class CrateVersionPicker extends Component {
           <img src={searchSvg} alt="search" />
         </div>{' '}
         <Autocomplete
-          id="crate-version-picker"
+          id="rubygems-version-picker"
+          selected={selected}
           options={list}
           defaultInputValue={defaultInputValue}
-          placeholder={options.length === 0 ? 'Could not fetch versions, type a Crate version' : 'Pick a Crate version'}
+          placeholder={
+            options.length === 0 ? 'Could not fetch versions, type a RubyGem version' : 'Pick a RubyGem version'
+          }
           onChange={this.onChange}
-          positionFixed
-          clearButton
           onFocus={() => this.setState({ ...this.state, focus: true })}
           onBlur={() => this.setState({ ...this.state, focus: false })}
+          positionFixed
+          clearButton
           allowNew
           newSelectionPrefix="Version:"
           emptyLabel=""
-          // filterBy={this.filter}
+          filterBy={this.filter}
           selectHintOnEnter
         />
       </div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,17 +12,17 @@ from './ContributePrompt'
 export { default as CopyUrlButton }
 from './CopyUrlButton'
 export { default as CrateSelector }
-from './CrateSelector'
+from './Providers/Selectors/CrateSelector'
 export { default as CrateVersionPicker }
-from './CrateVersionPicker'
+from './Providers/VersionPickers/CrateVersionPicker'
 export { default as DebianSelector }
 from './Providers/Selectors/DebianSelector'
 export { default as DebianVersionPicker }
 from './Providers/VersionPickers/DebianVersionPicker'
 export { default as ComposerSelector }
-from './ComposerSelector'
+from './Providers/Selectors/ComposerSelector'
 export { default as ComposerVersionPicker }
-from './ComposerVersionPicker'
+from './Providers/VersionPickers/ComposerVersionPicker'
 export { default as DefinitionEntry }
 from './DefinitionEntry'
 export { default as FieldGroup }
@@ -34,9 +34,9 @@ from './FilterBar'
 export { default as Footer }
 from './Footer'
 export { default as GitHubCommitPicker }
-from './GitHubCommitPicker'
+from './Providers/VersionPickers/GitHubCommitPicker'
 export { default as GitHubSelector }
-from './GitHubSelector'
+from './Providers/Selectors/GitHubSelector'
 export { default as HarvestQueueList }
 from './HarvestQueueList'
 export { default as Header }
@@ -50,31 +50,31 @@ from './ModalEditor'
 export { default as SourcePicker }
 from './SourcePicker'
 export { default as MavenSelector }
-from './MavenSelector'
+from './Providers/Selectors/MavenSelector'
 export { default as MavenVersionPicker }
-from './MavenVersionPicker'
+from './Providers/VersionPickers/MavenVersionPicker'
 export { default as NotificationList }
 from './NotificationList'
 export { default as NpmSelector }
-from './NpmSelector'
+from './Providers/Selectors/NpmSelector'
 export { default as NpmVersionPicker }
-from './NpmVersionPicker'
+from './Providers/VersionPickers/NpmVersionPicker'
 export { default as NuGetSelector }
-from './NuGetSelector'
+from './Providers/Selectors/NuGetSelector'
 export { default as NuGetVersionPicker }
-from './NuGetVersionPicker'
+from './Providers/VersionPickers/NuGetVersionPicker'
 export { default as PyPiSelector }
-from './PyPiSelector'
+from './Providers/Selectors/PyPiSelector'
 export { default as PyPiVersionPicker }
-from './PyPiVersionPicker'
+from './Providers/VersionPickers/PyPiVersionPicker'
 export { default as RubyGemsSelector }
-from './RubyGemsSelector'
+from './Providers/Selectors/RubyGemsSelector'
 export { default as RubyGemsVersionPicker }
-from './RubyGemsVersionPicker'
+from './Providers/VersionPickers/RubyGemsVersionPicker'
 export { default as CocoaPodsSelector }
-from './CocoaPodsSelector'
+from './Providers/Selectors/CocoaPodsSelector'
 export { default as CocoaPodsVersionPicker }
-from './CocoaPodsVersionPicker'
+from './Providers/VersionPickers/CocoaPodsVersionPicker'
 export { default as PageAbout }
 from './PageAbout'
 export { default as RehydrationProvider }


### PR DESCRIPTION
To be consistent with DebianSelector and DebianVersionPicker

Test cases:
-tested package searching for all affected providers in the harvest page. (During testing, found an issue with crate.io search, tracked as https://github.com/clearlydefined/service/issues/938)

-SourcePicker (using GitHubSelector and GitHubCommitPicker) is also tested via definition page
(http://localhost:3000/definitions/pod/cocoapods/-/SoftButton/0.1.0) by editting Described.Source.

