### PR TITLE
Support component search by provider

### DIFF
--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -34,7 +34,8 @@ class PageBrowse extends SystemManagedList {
     this.state = {
       activeSort: 'releaseDate-desc',
       searchFocused: false,
-      selectedProvider: providers[0]
+      selectedProvider: providers[0],
+      searchTerm: ''
     }
     this.onFilter = this.onFilter.bind(this)
     this.onSort = this.onSort.bind(this)
@@ -63,11 +64,17 @@ class PageBrowse extends SystemManagedList {
   }
 
   onBrowse = value => {
-    this.setState({ activeName: value }, () => this.updateData())
+    this.setState({ activeName: value, searchTerm: '' }, () => this.updateData())
   }
 
   onFocusChange = value => {
     this.setState({ searchFocused: value })
+  }
+
+  onSearch = value => {
+    this.setState({ searchTerm: value })
+    const provider = this.state.selectedProvider.value
+    super.onSearch(provider + '/' + value)
   }
 
   tableTitle() {
@@ -163,6 +170,7 @@ class PageBrowse extends SystemManagedList {
 
   onProviderChange(item) {
     this.setState({ selectedProvider: item })
+    this.state.searchTerm && super.onSearch(item.value + '/' + this.state.searchTerm)
   }
 
   // Overrides the default onFilter method


### PR DESCRIPTION
1. Added provider to the pattern string for coordinates suggestion
The search api call in service ignores provider type.
For example, the following call return co-ordinates with provider other than npmjs:
curl -X GET "https://dev-api.clearlydefined.io/definitions?pattern=jw&type=npm" -H "accept: */*"
This is probably by design: the suggestion api only takes the pattern
string into account.

When provider is included in the pattern string, the search result
reflects the provider specification. The solution is to pass the
provider information when searching in PageBrowse.

2. Also trigger search when provider is changed

Task: https://github.com/clearlydefined/website/issues/957