### PR TITLE
Fixed curation for certain go components

### DIFF
--- a/src/api/clearlyDefined.js
+++ b/src/api/clearlyDefined.js
@@ -138,7 +138,7 @@ export function getSuggestedData(token, entity) {
 }
 
 export function previewDefinition(token, entity, curation) {
-  return post(url(`${DEFINITIONS}/${entity.toPath()}`, { preview: true, matchCasing: 'false' }), token, curation)
+  return patch(url(DEFINITIONS), token, { coordinates: entity.toPath(), curation })
 }
 
 export async function getNotices(token, coordinates, renderer, options) {


### PR DESCRIPTION
The curation for certain go components failed due to the failure of preview definition service call.
Update the preview definition call to the newly added api endpoint. 

The PR is dependent on https://github.com/clearlydefined/service/pull/944

Task: https://github.com/clearlydefined/website/issues/920