### PR TITLE
Fix and enhance component buttons

### DIFF
--- a/src/actions/definitionActions.js
+++ b/src/actions/definitionActions.js
@@ -56,7 +56,7 @@ export function checkForMissingDefinition(token, isFirstAttempt = false) {
     ).filter(x => x)
     const missingDefinitions = map(
       workspaceComponents,
-      item => !get(item, 'described.tools') && EntitySpec.fromObject(item).toPath()
+      item => !get(item, 'described.tools') && EntitySpec.fromObject(item.coordinates).toPath()
     ).filter(x => x)
     if (missingDefinitions.length > 0) {
       if (isFirstAttempt)

--- a/src/components/FullDetailView/AbstractFullDetailsView.js
+++ b/src/components/FullDetailView/AbstractFullDetailsView.js
@@ -32,7 +32,8 @@ export class AbstractFullDetailsView extends Component {
 
     return modalView ? (
       <Modal
-        closable={false}
+        closable={!!this.handleClose}
+        onCancel={this.handleClose}
         footer={null}
         // if it's mobile do not center the Modal
         centered={!isMobile}
@@ -50,7 +51,6 @@ export class AbstractFullDetailsView extends Component {
             readOnly={readOnly}
             modalView={modalView}
             onChange={this.onChange}
-            handleClose={this.handleClose}
             handleSave={this.handleSave}
             handleRevert={this.handleRevert}
             previewDefinition={previewDefinition}

--- a/src/components/FullDetailView/FullDetailComponent.js
+++ b/src/components/FullDetailView/FullDetailComponent.js
@@ -29,7 +29,6 @@ class FullDetailComponent extends Component {
     }
   }
   static propTypes = {
-    handleClose: PropTypes.func,
     handleSave: PropTypes.func,
     handleRevert: PropTypes.func,
     curations: PropTypes.object.isRequired,

--- a/src/components/FullDetailView/FullDetailPage.js
+++ b/src/components/FullDetailView/FullDetailPage.js
@@ -166,9 +166,9 @@ export class FullDetailPage extends AbstractFullDetailsView {
   }
 
   handleClose() {
-    const { onClose } = this.props
+    const { readOnly, onClose } = this.props
     const { changes } = this.state
-    if (isEmpty(changes)) return onClose()
+    if (readOnly || isEmpty(changes)) return onClose()
     const key = `open${Date.now()}`
     notification.open({
       message: 'Unsaved Changes',

--- a/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
+++ b/src/components/Navigation/Pages/PageBrowse/PageBrowse.js
@@ -354,7 +354,6 @@ class PageBrowse extends SystemManagedList {
                   loadMoreRows={this.loadMoreRows}
                   onRevert={(definition, value) => this.revertDefinition(definition, value, 'browse')}
                   onChange={this.onChangeComponent}
-                  onInspect={this.onInspect}
                   renderFilterBar={this.renderFilterBar}
                   curations={curations}
                   definitions={definitions}

--- a/src/components/Navigation/Pages/PageDefinitions/PageDefinitions.js
+++ b/src/components/Navigation/Pages/PageDefinitions/PageDefinitions.js
@@ -23,7 +23,6 @@ import UrlShare from '../../../../utils/urlShare'
 export class PageDefinitions extends UserManagedList {
   constructor(props) {
     super(props)
-    this.onAddComponent = this.onAddComponent.bind(this)
     this.doSave = this.doSave.bind(this)
     this.doSaveAsUrl = this.doSaveAsUrl.bind(this)
     this.revertAll = this.revertAll.bind(this)
@@ -225,7 +224,7 @@ export class PageDefinitions extends UserManagedList {
             path={path}
             currentDefinition={currentDefinition}
             component={currentComponent}
-            readOnly={this.readOnly}
+            readOnly={true}
           />
         )}
         {showSavePopup && (

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -6,9 +6,11 @@ import EntitySpec from '../../../utils/entitySpec'
 import { ROUTE_DEFINITIONS } from '../../../utils/routingConstants'
 import { withResize } from '../../../utils/WindowProvider'
 import Definition from '../../../utils/definition'
+import { ORIGINS } from '../../../api/clearlyDefined'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 import { IconButton } from '@material-ui/core'
 import ButtonWithTooltip from './ButtonWithTooltip'
+import { Menu, Dropdown, Icon } from 'antd'
 
 class ComponentButtons extends Component {
   constructor(props) {
@@ -31,6 +33,10 @@ class ComponentButtons extends Component {
 
   isSourceComponent(component) {
     return ['github', 'sourcearchive', 'debsrc'].includes(component.provider)
+  }
+
+  _isProviderSupported(component) {
+    return !!get(ORIGINS, component.provider)
   }
 
   removeComponent(component, event) {
@@ -86,40 +92,50 @@ class ComponentButtons extends Component {
   }
 
   renderDropdown(currentComponent) {
-    // return (
-    //   <Dropdown
-    //     trigger={['click']}
-    //     overlay={
-    //       <Menu>
-    //         <Menu.Item
-    //           data-test-id="switch-component-version"
-    //           onClick={this.showVersionSelectorPopup.bind(this, currentComponent, false)}
-    //         >
-    //           Switch version
-    //         </Menu.Item>
-    //         <Menu.Item
-    //           data-test-id="add-component-version"
-    //           onClick={this.showVersionSelectorPopup.bind(this, currentComponent, true)}
-    //         >
-    //           Add more versions
-    //         </Menu.Item>
-    //       </Menu>
-    //     }
-    //   >
-    //     <Button className="list-fa-button" onClick={event => event.stopPropagation()}>
-    //       <i className="fas fa-exchange-alt" /> <Icon type="down" />
-    //     </Button>
-    //   </Dropdown>
-    // )
+    return (
+      <Dropdown
+        trigger={['click']}
+        overlay={
+          <Menu>
+            <Menu.Item
+              data-test-id="switch-component-version"
+              onClick={this.showVersionSelectorPopup.bind(this, currentComponent, false)}
+            >
+              Switch version
+            </Menu.Item>
+            <Menu.Item
+              data-test-id="add-component-version"
+              onClick={this.showVersionSelectorPopup.bind(this, currentComponent, true)}
+            >
+              Add more versions
+            </Menu.Item>
+          </Menu>
+        }
+      >
+        <Button className="list-fa-button" onClick={event => event.stopPropagation()}>
+          <i className="fas fa-exchange-alt" /> <Icon type="down" />
+        </Button>
+      </Dropdown>
+    )
   }
 
   renderButtonGroup() {
-    const { definition, currentComponent, hasChange, readOnly, onAddComponent, onInspect, onRemove } = this.props
+    const {
+      definition,
+      currentComponent,
+      hasChange,
+      readOnly,
+      onAddComponent,
+      onInspect,
+      onRemove,
+      hideVersionSelector
+    } = this.props
     const component = EntitySpec.fromObject(currentComponent)
 
     const isSourceComponent = this.isSourceComponent(component)
     const isSourceEmpty = Definition.isSourceEmpty(definition)
     const isDefinitionEmpty = Definition.isDefinitionEmpty(definition)
+    const isProviderSupported = this._isProviderSupported(component)
     return (
       <>
         <IconButton className="menuOpenBtn" onClick={this.handleMenu} aria-label="button">
@@ -153,11 +169,11 @@ class ComponentButtons extends Component {
             >
               <i className="fas fa-external-link-alt" />
             </a>
-            {/*!hideVersionSelector && (
+            {!hideVersionSelector && isProviderSupported && (
               <ButtonWithTooltip tip="Switch or add other versions of this definition">
                 {this.renderDropdown(currentComponent)}
               </ButtonWithTooltip>
-            )*/}
+            )}
             {!readOnly && onRemove && (
               <ButtonWithTooltip tip="Remove this definition">
                 <Button className="list-fa-button" onClick={this.removeComponent.bind(this, currentComponent)}>

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -35,6 +35,7 @@ class ComponentButtons extends Component {
 
   removeComponent(component, event) {
     event.stopPropagation()
+    this.handleMenu()
     const { onRemove } = this.props
     onRemove && onRemove(component)
   }
@@ -113,7 +114,7 @@ class ComponentButtons extends Component {
   }
 
   renderButtonGroup() {
-    const { definition, currentComponent, hasChange, readOnly, onAddComponent, onInspect } = this.props
+    const { definition, currentComponent, hasChange, readOnly, onAddComponent, onInspect, onRemove } = this.props
     const component = EntitySpec.fromObject(currentComponent)
 
     const isSourceComponent = this.isSourceComponent(component)
@@ -157,6 +158,13 @@ class ComponentButtons extends Component {
                 {this.renderDropdown(currentComponent)}
               </ButtonWithTooltip>
             )*/}
+            {!readOnly && onRemove && (
+              <ButtonWithTooltip tip="Remove this definition">
+                <Button className="list-fa-button" onClick={this.removeComponent.bind(this, currentComponent)}>
+                  <i className="fas fa-trash" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
             {!readOnly && !isDefinitionEmpty && (
               <ButtonWithTooltip tip="Revert Changes of this Definition">
                 <Button

--- a/src/components/Navigation/Ui/ComponentButtons.js
+++ b/src/components/Navigation/Ui/ComponentButtons.js
@@ -1,12 +1,15 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'lodash'
-import { ButtonToolbar, Dropdown as BSDropdown } from 'react-bootstrap'
+import { Button, ButtonGroup, ButtonToolbar, Dropdown as BSDropdown } from 'react-bootstrap'
 import EntitySpec from '../../../utils/entitySpec'
 import { ROUTE_DEFINITIONS } from '../../../utils/routingConstants'
 import { withResize } from '../../../utils/WindowProvider'
+import Definition from '../../../utils/definition'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
 import { IconButton } from '@material-ui/core'
+import ButtonWithTooltip from './ButtonWithTooltip'
+
 class ComponentButtons extends Component {
   constructor(props) {
     super(props)
@@ -37,18 +40,21 @@ class ComponentButtons extends Component {
   }
 
   revertComponent(component, param) {
+    this.handleMenu()
     const { onRevert } = this.props
     onRevert && onRevert(component, param)
   }
 
   inspectComponent(component, definition, event) {
     event.stopPropagation()
+    this.handleMenu()
     const action = this.props.onInspect
     action && action(component, definition)
   }
 
   addSourceForComponent(component, event) {
     event.stopPropagation()
+    this.handleMenu()
     const definition = this.props.getDefinition(component)
     const sourceLocation = get(definition, 'described.sourceLocation')
     const sourceEntity = sourceLocation && EntitySpec.fromObject(sourceLocation)
@@ -58,6 +64,7 @@ class ComponentButtons extends Component {
 
   showVersionSelectorPopup(component, multiple, event) {
     event.domEvent.stopPropagation()
+    this.handleMenu()
     this.props.showVersionSelectorPopup(component, multiple)
   }
 
@@ -77,111 +84,92 @@ class ComponentButtons extends Component {
     )
   }
 
+  renderDropdown(currentComponent) {
+    // return (
+    //   <Dropdown
+    //     trigger={['click']}
+    //     overlay={
+    //       <Menu>
+    //         <Menu.Item
+    //           data-test-id="switch-component-version"
+    //           onClick={this.showVersionSelectorPopup.bind(this, currentComponent, false)}
+    //         >
+    //           Switch version
+    //         </Menu.Item>
+    //         <Menu.Item
+    //           data-test-id="add-component-version"
+    //           onClick={this.showVersionSelectorPopup.bind(this, currentComponent, true)}
+    //         >
+    //           Add more versions
+    //         </Menu.Item>
+    //       </Menu>
+    //     }
+    //   >
+    //     <Button className="list-fa-button" onClick={event => event.stopPropagation()}>
+    //       <i className="fas fa-exchange-alt" /> <Icon type="down" />
+    //     </Button>
+    //   </Dropdown>
+    // )
+  }
+
   renderButtonGroup() {
-    const { definition, currentComponent, hasChange } = this.props
+    const { definition, currentComponent, hasChange, readOnly, onAddComponent, onInspect } = this.props
     const component = EntitySpec.fromObject(currentComponent)
+
+    const isSourceComponent = this.isSourceComponent(component)
+    const isSourceEmpty = Definition.isSourceEmpty(definition)
+    const isDefinitionEmpty = Definition.isDefinitionEmpty(definition)
     return (
       <>
         <IconButton className="menuOpenBtn" onClick={this.handleMenu} aria-label="button">
           <MoreVertIcon fontSize="large" />
         </IconButton>
         <div className={`clearly-menu ${this.state.menuOpen ? 'opened' : 'closed'}`}>
-          <a
-            href={`${window.location.origin}${ROUTE_DEFINITIONS}/${component.toPath()}`}
-            onClick={event => {
-              this.handleMenu()
-            }}
-            className="clearly-menu-btns"
-          >
-            View Components
-          </a>
-          <button
-            onClick={() => {
-              this.handleMenu()
-              this.revertComponent(component)
-            }}
-            className={`clearly-menu-btns ${!hasChange(component) ? 'disabled-btn' : ''}`}
-            disabled={!hasChange(component)}
-          >
-            Revert Changes
-          </button>
-          <button
-            onClick={() => {
-              this.handleMenu()
-              this.inspectComponent.bind(this, currentComponent, definition)
-            }}
-            className="clearly-menu-btns"
-          >
-            Add Source Definition
-          </button>
-        </div>
-
-        {/*
-        <ButtonGroup>
-          {!isSourceComponent && !readOnly && !isSourceEmpty && (
-            <ButtonWithTooltip tip="Add the definition for source that matches this package">
-              <Button className="list-fa-button" onClick={this.addSourceForComponent.bind(this, component)}>
-                <i className="fas fa-code" />
-              </Button>
-            </ButtonWithTooltip>
-          )}
-          {!isDefinitionEmpty && (
-            <ButtonWithTooltip tip="Dig into this definition">
+          <ButtonGroup>
+            {!isSourceComponent && !readOnly && !isSourceEmpty && onAddComponent && (
+              <ButtonWithTooltip tip="Add the definition for source that matches this package">
+                <Button className="list-fa-button" onClick={this.addSourceForComponent.bind(this, component)}>
+                  <i className="fas fa-code" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
+            {!isDefinitionEmpty && onInspect && (
+              <ButtonWithTooltip tip="Dig into this definition">
               <Button className="list-fa-button" onClick={this.inspectComponent.bind(this, currentComponent, definition)}>
-                <i className="fas fa-search" />
-              </Button>
-            </ButtonWithTooltip>
-          )}
-          <a
-            href={`${window.location.origin}${ROUTE_DEFINITIONS}/${component.toPath()}`}
-            className="list-fa-button"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={event => event.stopPropagation()}
-          >
-            <i className="fas fa-external-link-alt" />
-          </a>
-          {!hideVersionSelector && (
-            <ButtonWithTooltip tip="Switch or add other versions of this definition">
-              <>
-                <Dropdown
-                  trigger={['click']}
-                  overlay={
-                    <Menu>
-                      <Menu.Item
-                        data-test-id="switch-component-version"
-                        onClick={this.showVersionSelectorPopup.bind(this, currentComponent, false)}
-                      >
-                        Switch version
-                      </Menu.Item>
-                      <Menu.Item
-                        data-test-id="add-component-version"
-                        onClick={this.showVersionSelectorPopup.bind(this, currentComponent, true)}
-                      >
-                        Add more versions
-                      </Menu.Item>
-                    </Menu>
-                  }
+                  <i className="fas fa-search" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
+            <a
+              href={`${window.location.origin}${ROUTE_DEFINITIONS}/${component.toPath()}`}
+              className="list-fa-button btn btn-default"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={event => {
+                this.handleMenu()
+                event.stopPropagation()
+              }}
+            >
+              <i className="fas fa-external-link-alt" />
+            </a>
+            {/*!hideVersionSelector && (
+              <ButtonWithTooltip tip="Switch or add other versions of this definition">
+                {this.renderDropdown(currentComponent)}
+              </ButtonWithTooltip>
+            )*/}
+            {!readOnly && !isDefinitionEmpty && (
+              <ButtonWithTooltip tip="Revert Changes of this Definition">
+                <Button
+                  className="list-fa-button"
+                  onClick={() => this.revertComponent(component)}
+                  disabled={!hasChange(component)}
                 >
-                  <Button className="list-fa-button" onClick={event => event.stopPropagation()}>
-                    <i className="fas fa-exchange-alt" /> <Icon type="down" />
-                  </Button>
-                </Dropdown>
-              </>
-            </ButtonWithTooltip>
-          )}
-          {!readOnly && !isDefinitionEmpty && (
-            <ButtonWithTooltip tip="Revert Changes of this Definition">
-              <Button
-                className="list-fa-button"
-                onClick={() => this.revertComponent(component)}
-                disabled={!hasChange(component)}
-              >
-                <i className="fas fa-undo" />
-              </Button>
-            </ButtonWithTooltip>
-          )}
-        </ButtonGroup> */}
+                  <i className="fas fa-undo" />
+                </Button>
+              </ButtonWithTooltip>
+            )}
+          </ButtonGroup>
+        </div>
       </>
     )
   }

--- a/src/components/Navigation/Ui/VersionSelector.js
+++ b/src/components/Navigation/Ui/VersionSelector.js
@@ -29,7 +29,7 @@ class VersionSelector extends Component {
     const fullname = component.namespace ? `${component.namespace}/${component.name}` : component.name
     try {
       const label = multiple
-        ? `Pick one or move versions of ${fullname} to add to the definitions list`
+        ? `Add one or more versions of ${fullname}`
         : `Pick a different version of ${fullname}`
       const options = await getRevisions(token, fullname, component.type, component.provider)
       this.setState({ options, label })
@@ -58,7 +58,7 @@ class VersionSelector extends Component {
     const { options, label, selected } = this.state
 
     return (
-      <Modal show={show} onHide={this.onClose} backdrop={selected.length > 0 ? 'static' : true}>
+      <Modal show={show} onHide={this.onClose} backdrop={selected.length > 0 ? 'static' : true} dialogClassName='version-selector'>
         <Modal.Header closeButton>
           <Modal.Title>{label}</Modal.Title>
         </Modal.Header>
@@ -67,8 +67,10 @@ class VersionSelector extends Component {
             <Select
               mode={multiple && 'multiple'}
               style={{ width: '100%' }}
+              dropdownClassName='select-in-modal'
               placeholder={label}
               onChange={this.handleChange}
+              defaultValue={component?.revision}
             >
               {options.map(option => (
                 <Option key={Definition.getRevisionToKey(option, component)}>

--- a/src/components/SystemManagedList.js
+++ b/src/components/SystemManagedList.js
@@ -51,6 +51,7 @@ export default class SystemManagedList extends Component {
     this.updateList = this.updateList.bind(this)
     this.onSearch = this.onSearch.bind(this)
     this.onInspect = this.onInspect.bind(this)
+    this.onInspectClose = this.onInspectClose.bind(this)
     this.onSort = this.onSort.bind(this)
     this.onFilter = this.onFilter.bind(this)
     this.onChangeComponent = this.onChangeComponent.bind(this)

--- a/src/styles/_Popover.scss
+++ b/src/styles/_Popover.scss
@@ -219,7 +219,7 @@ button.modal__btn--secondary,
   }
 }
 
-.fade.in.definition__tooltip.tooltip,
+.fade.in.tooltip,
 .fade.in.modal {
   opacity: 1 !important;
 }

--- a/src/styles/_VersionSelector.scss
+++ b/src/styles/_VersionSelector.scss
@@ -1,0 +1,22 @@
+.version-selector {
+  .modal-header {
+    padding: 15px;
+    display: block;
+  }
+  button.close {
+    border: 0;
+  }
+  .close {
+    color: #000;
+    filter: alpha(opacity=20);
+    float: right;
+    font-size: 21px;
+    font-weight: 700;
+    line-height: 1;
+    opacity: .2;
+    text-shadow: 0 1px 0 #fff;
+  }  
+}
+.select-in-modal.ant-select-dropdown {
+  z-index: 1100;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -76,5 +76,6 @@ main {
 @import './PageAbout.scss';
 @import './charter.scss';
 @import './ShareButton.scss';
+@import './VersionSelector.scss';
 
 @import './utils.scss';


### PR DESCRIPTION
This is to address some of the issues tracked in https://github.com/clearlydefined/website/issues/946.

-Viewing components (Inspect) is supported in workspace and curation.
-Adding source component, switching to other version, and adding more versions are now supported in workspace.
-Deleting component is also enabled in workspace
