### PR TITLE
Fix display of ShareButton dropdown in workspace view

### DIFF
--- a/src/components/Navigation/Pages/PageDefinitions/ButtonsBar.js
+++ b/src/components/Navigation/Pages/PageDefinitions/ButtonsBar.js
@@ -5,6 +5,11 @@ import ButtonWithTooltip from '../../Ui/ButtonWithTooltip'
 import ShareButton from '../../Ui/ShareButton'
 
 export default class ButtonsBar extends Component {
+  constructor(props) {
+    super(props)
+    this.onSelect = this.onSelect.bind(this)
+  }
+
   static propTypes = {
     components: PropTypes.object,
     hasChanges: PropTypes.bool,

--- a/src/components/Navigation/Ui/ShareButton.js
+++ b/src/components/Navigation/Ui/ShareButton.js
@@ -13,18 +13,18 @@ export default class ShareButton extends Component {
     const disabled = !components || components.list.length === 0
     return (
       <DropdownButton disabled={disabled} id={'sharedropdown'} title="Share" bsStyle="success">
-        <MenuItem eventKey="1" onSelect={() => onSelect('url')}>
+        <MenuItem eventKey="1" className="dropdown-item" onSelect={() => onSelect('url')}>
           URL
         </MenuItem>
-        <MenuItem eventKey="2" onSelect={() => onSelect('file')}>
+        <MenuItem eventKey="2" className="dropdown-item" onSelect={() => onSelect('file')}>
           Coordinate list (JSON)
         </MenuItem>
-        <MenuItem eventKey="2" onSelect={() => onSelect('notice')}>
+        <MenuItem eventKey="2" className="dropdown-item" onSelect={() => onSelect('notice')}>
           Notice file
         </MenuItem>
-        <MenuItem divider />
+        {/* <MenuItem divider />
         <MenuItem disabled>Definitions (Not implemented)</MenuItem>
-        <MenuItem disabled>SPDX (Not implemented)</MenuItem>
+        <MenuItem disabled>SPDX (Not implemented)</MenuItem> */}
       </DropdownButton>
     )
   }

--- a/src/styles/_ShareButton.scss
+++ b/src/styles/_ShareButton.scss
@@ -1,0 +1,11 @@
+.open > .dropdown-menu {
+  display: block;
+}
+
+.dropdown.btn-group {
+  display: inline-block;
+}
+
+.dropdown-item > a {
+  display: block;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -75,5 +75,6 @@ main {
 @import './GetInvolved.scss';
 @import './PageAbout.scss';
 @import './charter.scss';
+@import './ShareButton.scss';
 
 @import './utils.scss';


### PR DESCRIPTION
ShareButton uses DropdownButton from Bootstrap 3.
Bootstrap 3 uses open class for expanded drop down.  The imported
bootstrap 5 styling uses show class for expanded drop down.  Added
the missing Bootstrap 3 styling necessary for the drop down to be
correctly displayed.

Also utilize the existing Bootstrap 5 styling class for the menu item to
avoid copying over more styling classes

Task: https://github.com/clearlydefined/website/issues/946