### PR TITLE
Fix scrolling in ComponentList

### DIFF
--- a/src/components/ComponentList.js
+++ b/src/components/ComponentList.js
@@ -145,8 +145,9 @@ class ComponentList extends React.Component {
   render() {
     const { loadMoreRows, noRowsRenderer, list, listLength } = this.props
     const { sortOrder, contentSeq } = this.state
+    const showFilterBar = false
     return (
-      <div className="clearly-table-body flex-grow">
+      <div className={`clearly-table-body flex-grow ${showFilterBar ? 'show-filter' : ''}`}>
         <div className="clearly-header">
           <div className="table-header-fcloumn">
             <h4>Component</h4>

--- a/src/styles/_App.scss
+++ b/src/styles/_App.scss
@@ -240,7 +240,6 @@ main {
   box-shadow: 5px 5px 20px -10px lightgrey;
   display: flex;
   min-height: 200px;
-  padding-bottom: $height-filters-section;
 
   .fa-spinner {
     display: none;

--- a/src/styles/_List.scss
+++ b/src/styles/_List.scss
@@ -373,6 +373,10 @@
   height: $height-filters-list;
 }
 
+.show-filter.clearly-table-body {
+  margin-bottom: $height-filters-section;
+}
+
 .filter-list,
 .list-filter,
 .section--filter-bar {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -433,13 +433,12 @@ a:hover {
   /* min-height: 550px; */
   /* max-height: 700px; */
   overflow: hidden;
-  height: 60vh;
   position: relative;
   width: 100%;
   will-change: transform; }
 
 .clearly-table-body .form-group.flex-grow-column {
-  height: 100%;
+  height: 60vh;
   width: 100%; }
 
 .clearly-table .form-group.flex-grow-column .checkbox {


### PR DESCRIPTION
1. The height on the clearly-table-body crops the scroll bar, so
scrolling cannot reach the item at the end of the list.  Moved the
height styling to address this.

2. There is a blank space after components in the table even when
there is not enough space to display all the components.  This is
because renderFilterBar, passed as props from the container components
(e.g. PageDefinition), is not called in ComponentList.  Padding to
accommodate the FilterBar is added by the parent of the ComponentList,
thus leaving a blank space after the ComponentList when FilterBar is
not rendered inside ComponentList.

Change the spacing from padding in the section (parent) to margin of
the ComponentList (child), where showing filter bar is determined.
Also add the conditional formatting to control the spacing based on
whether filter bar is displayed.

Task: https://github.com/clearlydefined/website/issues/946