### PR TITLE
Fixing file viewer table layout

### DIFF
--- a/src/styles/_FullDetailComponent.scss
+++ b/src/styles/_FullDetailComponent.scss
@@ -596,6 +596,10 @@
     }
   }
 
+  table {
+    table-layout: fixed;
+  }
+
   .directory-folder-icon {
     padding-right: 10px;
   }


### PR DESCRIPTION
Fixing table layout to hide long license lists.

Current:
<img width="899" alt="image" src="https://github.com/clearlydefined/website/assets/5489711/987d8c4f-5eb3-40fd-beaf-80e51265bb3a">

Proposed change:
<img width="869" alt="image" src="https://github.com/clearlydefined/website/assets/5489711/bd0686c1-a2f1-4163-b202-20e34d32521f">

Tested on: https://clearlydefined.io/definitions/maven/mavencentral/com.hazelcast/hazelcast/5.3.0/5.3.0