### PR TITLE
Add GitHub Actions workflow file to run CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - uses: actions/setup-node@v4.0.1
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4.0.1
         with:
-          node-version: 18
+          node-version: 10
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
To complete the switch to GitHub Actions across crawler, service, and website, this adds the same GitHub Actions workflow file that's already running in the other two repos on every pull request.

Once this is merged and verified, I'll follow up with removing the Azure Pipelines config.