### PR TITLE
use v2.0.0 deploy & pass docker build args

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -7,8 +7,23 @@ on:
     branches: [master]
 
 jobs:
+  upload-package-lock-json:
+    name: Upload package-lock.json from this repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Upload package-lock.json
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-lock.json
+          path: package-lock.json
+
   build-and-deploy:
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v1.0.0
+    name: Build and Deploy
+    needs: upload-package-lock-json
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v2.0.0
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}
@@ -19,3 +34,5 @@ jobs:
       application-type: ui
       azure-app-base-name: clearlydefined
       azure-app-name-postfix: -dev
+      docker-build-args: |
+        REACT_APP_SERVER="https://dev.clearlydefined.io"

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -35,4 +35,5 @@ jobs:
       azure-app-base-name: clearlydefined
       azure-app-name-postfix: -dev
       docker-build-args: |
-        REACT_APP_SERVER="https://dev.clearlydefined.io"
+        REACT_APP_SERVER="https://dev-api.clearlydefined.io"
+        REACT_APP_GA_TRACKINGID="${{ secrets.REACT_APP_GA_TRACKINGID_DEV }}"


### PR DESCRIPTION
Fixes #1057 

----

## Description

The v2.0.0 deploy workflows support passing docker build args to the docker build.  This fixes the problem where the `REACT_APP_SERVER` arg to docker was not set.  This was causing the website to communicate with the service at localhost:4000 instead of the expected dev.clearlydefined.io.  The change also adds a new job to upload the package-lock.json file to the build artifacts.  This is needed for the build-and-deploy job to be able to get the version from that file.

### Related Work

* https://github.com/clearlydefined/operations/pull/86
* https://github.com/clearlydefined/service/pull/1154
