### PR TITLE
Remove quotes from all docker build-args

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -45,5 +45,5 @@ jobs:
       azure-app-base-name: clearlydefined
       azure-app-name-postfix: -dev
       docker-build-args: |
-        REACT_APP_SERVER="https://dev-api.clearlydefined.io"
+        REACT_APP_SERVER=https://dev-api.clearlydefined.io
         REACT_APP_GA_TRACKINGID="${{ needs.make-react-secret-available.outputs.trackingid }}"

--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -46,4 +46,4 @@ jobs:
       azure-app-name-postfix: -dev
       docker-build-args: |
         REACT_APP_SERVER=https://dev-api.clearlydefined.io
-        REACT_APP_GA_TRACKINGID="${{ needs.make-react-secret-available.outputs.trackingid }}"
+        REACT_APP_GA_TRACKINGID=${{ needs.make-react-secret-available.outputs.trackingid }}


### PR DESCRIPTION
### Description

Build args that are in quotes have the quotes encoded leading to an incorrect value when the Docker image is built.  This removes the quotes.  The dev website was confirmed to load correctly after this change.