### PR TITLE
Add health endpoint via nginx

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -33,7 +33,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     needs: [upload-package-lock-json, make-react-secret-available]
-    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v2.0.0
+    uses: clearlydefined/operations/.github/workflows/app-build-and-deploy.yml@v3.1.2
     secrets: 
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       AZURE_WEBAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_DEV }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,14 @@ RUN npm install -g npm@9
 RUN npm install
 RUN npm run build
 
-FROM nginx:alpine
-ADD nginx.conf /etc/nginx/conf.d/default.conf
+FROM nginx:1.19.6-alpine
+
+ARG APP_VERSION="UNKNOWN"
+ENV APP_VERSION=$APP_VERSION
+ARG BUILD_SHA="UNKNOWN"
+ENV BUILD_SHA=$BUILD_SHA
+
+RUN mkdir /etc/nginx/templates
+COPY default.conf.template /etc/nginx/templates
 COPY --from=builder /opt/website/build /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@
 FROM node:14-alpine as builder
 COPY . /opt/website
 WORKDIR /opt/website
+
+# Set environment variables from build arguments
+ARG APP_VERSION="UNKNOWN"
+ENV APP_VERSION=$APP_VERSION
+ARG BUILD_SHA="UNKNOWN"
+ENV BUILD_SHA=$BUILD_SHA
+
 ARG REACT_APP_SERVER=http://localhost:4000
 ARG REACT_APP_GA_TRACKINGID
 RUN apk add --no-cache git

--- a/default.conf.template
+++ b/default.conf.template
@@ -12,12 +12,9 @@ server {
         etag off;
     }
 
-    location /nginx_health {
-      set_by_lua $app_version 'return os.getenv("APP_VERSION")';
-      set_by_lua $build_sha 'return os.getenv("BUILD_SHA")';
-
-      default_type application/json;
-      return 200 '{"status":"OK", "version": "$app_version", "sha": "$build_sha"}';
+    location /health {
+      add_header 'Content-Type' 'application/json';
+      return 200 '{"status":"OK", "version": "${APP_VERSION}", "sha": "${BUILD_SHA}"}';
     }
 
     # redirect server error pages to the static page /50x.html

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,14 @@ server {
         etag off;
     }
 
+    location /nginx_health {
+      set_by_lua $app_version 'return os.getenv("APP_VERSION")';
+      set_by_lua $build_sha 'return os.getenv("BUILD_SHA")';
+
+      default_type application/json;
+      return 200 '{"status":"OK", "version": "$app_version", "sha": "$build_sha"}';
+    }
+
     # redirect server error pages to the static page /50x.html
     #
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Adds a health endpoint which returns app version and sha.

```
{"status":"OK", "version": "2.2.1", "sha": "12345"}
```

Endpoint has been implemented via nginx.
As the site is a React page the alternative would have been adding a Node.js endpoint the app would need to expose.
Using nginx is a lot less complex and easier to maintain in the future

Deployed to development and it's working:
```
curl https://dev.clearlydefined.io/health
=> {"status":"OK", "version": "v0.1.1-dev-654d7fca75", "sha": "654d7fca7516735b2e9891b8657352cf3b3e0a4e"}
```