### PR TITLE
Fixing file viewer table layout

### DIFF
--- a/src/styles/_FullDetailComponent.scss
+++ b/src/styles/_FullDetailComponent.scss
@@ -115,6 +115,12 @@
   outline: none;
 }
 
+.file-list .ant-table table,
+.directory-viewer .ant-table table {
+  table-layout: fixed;
+  width: 100%;
+}
+
 .file-list {
   .ant-table-row-collapsed,
   .ant-table-row-expanded {


### PR DESCRIPTION
This helps fix the table issue when there is a long string in a cell. Fixes #1029.

Tested on: https://clearlydefined.io/definitions/git/github/langfuse/langfuse/26e3bf9a444e735a211ef6ad89b0473e911825e9

Current:
<img width="1196" height="318" alt="image" src="https://github.com/user-attachments/assets/2a2a27cc-922d-49d5-8fe4-0e78d5755761" />

Proposed fix:
<img width="1021" height="161" alt="image" src="https://github.com/user-attachments/assets/af55f834-dd70-457b-9980-521f8abe39b9" />


