### PR TITLE
UI fix for search input clipping issue

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -133,7 +133,8 @@ a:hover {
   border-top-left-radius: 30px;
   border-bottom-left-radius: 30px;
   outline: 0 !important;
-  box-shadow: 0 0 0 0.2rem rgba(29, 82, 212, 0.5) !important; }
+  box-shadow: 0 0 0 0.2rem rgba(29, 82, 212, 0.5) !important; 
+  z-index: 1; }
 
 .top-search-and-filter .right-side-filter {
   /* padding: 20px;
@@ -171,7 +172,6 @@ a:hover {
 
 .harvest-provider .provider-drop-down div input {
   border: 0;
-  border-radius: 50px 0px 0px 50px;
   font-size: 14px;
   height: 100%; }
 


### PR DESCRIPTION
Issue: [Search input focus outline is visually clipped by adjacent dropdown border radius](https://github.com/clearlydefined/website/issues/1131)